### PR TITLE
fix: address three correctness bugs from review (#2)

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -7,8 +7,12 @@ import { DEFAULT_CONFIG } from './defaults.js';
  * Interpolate ${VAR} references with environment variables.
  */
 function interpolateEnv(value: string): string {
-  return value.replace(/\$\{([^}]+)\}/g, (_, varName) => {
-    return process.env[varName.trim()] ?? '';
+  return value.replace(/\$\{([^}]+)\}/g, (match, varName) => {
+    const resolved = process.env[varName.trim()];
+    if (resolved === undefined) {
+      throw new Error(`Missing environment variable: ${varName.trim()} (referenced as ${match})`);
+    }
+    return resolved;
   });
 }
 
@@ -63,6 +67,7 @@ export function loadConfig(configPath?: string): ResolvedConfig {
         name,
         baseUrl: String(p.baseUrl ?? p.base_url ?? ''),
         apiKey: String(p.apiKey ?? p.api_key ?? ''),
+        format: p.format as string | undefined,
         models: p.models as Record<string, string> | undefined,
         defaultModel: p.defaultModel as string | undefined,
         timeout: p.timeout ? Number(p.timeout) : undefined,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -140,6 +140,7 @@ export interface ProviderConfig {
   name: string;
   baseUrl: string;
   apiKey: string;
+  format?: string; // e.g. 'openai' | 'anthropic' — used to resolve the correct transformer
   models?: Record<string, string>;
   defaultModel?: string;
   timeout?: number;

--- a/src/proxy/provider.ts
+++ b/src/proxy/provider.ts
@@ -48,7 +48,8 @@ export async function callProvider(opts: ProviderCallOptions): Promise<ProviderC
   const { providerConfig, transformer, body, timeout } = opts;
   const start = Date.now();
 
-  const url = `${providerConfig.baseUrl}/v1/chat/completions`;
+  const path = transformer.provider === 'anthropic' ? '/v1/messages' : '/v1/chat/completions';
+  const url = `${providerConfig.baseUrl}${path}`;
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -64,12 +64,19 @@ export function setupRoutes(app: Express, opts: RouterOptions) {
 
         const providers = providerNames
           .filter((name) => config.providers[name])
-          .map((name) => ({
-            config: config.providers[name],
-            transformer: transformRegistry.has(name)
-              ? transformRegistry.get(name)
-              : clientTransformer,
-          }));
+          .map((name) => {
+            const providerCfg = config.providers[name];
+            // Resolve transformer by explicit format, inferred from baseUrl, or fallback to client format
+            const format = providerCfg.format
+              ?? (providerCfg.baseUrl.includes('anthropic') ? 'anthropic' : undefined)
+              ?? (providerCfg.baseUrl.includes('openai') ? 'openai' : undefined);
+            return {
+              config: providerCfg,
+              transformer: format && transformRegistry.has(format)
+                ? transformRegistry.get(format)
+                : clientTransformer,
+            };
+          });
 
         // Determine target provider format
         const primaryProvider = providers[0];


### PR DESCRIPTION
Addresses issue #2

Clean rebase of the fixes from PR #36 (which had merge conflict markers baked into its git history).

## Changes

1. **Fix non-streaming Anthropic endpoint** — `callProvider` now selects `/v1/messages` for Anthropic instead of hardcoding `/v1/chat/completions`
2. **Fix transformer resolution** — Resolves transformer by explicit `format` field on `ProviderConfig`, then infers from `baseUrl`, then falls back to client format (instead of checking provider name)
3. **Throw on missing env vars** — `${VAR}` references to undefined env vars now throw with a clear error message instead of silently resolving to empty string
4. **Add `format` field to `ProviderConfig`** — Enables explicit transformer selection in config