### PR TITLE
feat: fork-join + thinking wrapper composers (#12)

### DIFF
--- a/src/compose/fork-join.test.ts
+++ b/src/compose/fork-join.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CallProviderFn, CompositionStep } from '../core/composer.js';
+import { PipelineContext } from '../core/context.js';
+import { createTimeoutBudget } from '../core/timeout.js';
+import type { CanonicalResponse, ResolvedConfig } from '../core/types.js';
+import { PipelineError } from '../core/types.js';
+import { ForkJoinComposer } from './fork-join.js';
+
+function makeConfig(): ResolvedConfig {
+  return {
+    port: 3000,
+    logLevel: 'info',
+    requestTimeout: 30_000,
+    providers: {},
+    routes: [],
+  };
+}
+
+function makeResponse(content: string, model = 'gpt-4'): CanonicalResponse {
+  return {
+    id: 'resp-1',
+    model,
+    content: [{ type: 'text', text: content }],
+    stopReason: 'end',
+    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+  };
+}
+
+function makeCtx(timeout?: number): PipelineContext {
+  return new PipelineContext({
+    request: {
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'What is 2+2?' }],
+      systemPrompt: 'You are a math tutor.',
+    },
+    config: makeConfig(),
+    timeout: createTimeoutBudget(timeout ?? 30_000),
+  });
+}
+
+describe('ForkJoinComposer', () => {
+  it('has type "fork-join"', () => {
+    const composer = new ForkJoinComposer();
+    expect(composer.type).toBe('fork-join');
+  });
+
+  it('executes steps in parallel and concatenates by default', async () => {
+    const composer = new ForkJoinComposer({ merge: 'concatenate' });
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'openai') return makeResponse('OpenAI says 4');
+        return makeResponse('Anthropic says 4');
+      });
+
+    const steps: CompositionStep[] = [
+      { name: 'fork-a', provider: 'openai' },
+      { name: 'fork-b', provider: 'anthropic' },
+    ];
+
+    const result = await composer.execute(makeCtx(), steps, callProvider);
+
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps.every((s) => s.status === 'success')).toBe(true);
+    expect(result.finalResponse).toBeDefined();
+    expect(result.finalResponse!.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('OpenAI says 4'),
+    });
+    expect(result.finalResponse!.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('Anthropic says 4'),
+    });
+    // Both providers called
+    expect(callProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles partial fork failures gracefully', async () => {
+    const composer = new ForkJoinComposer({ merge: 'concatenate', minSuccessful: 1 });
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'failing') throw new Error('Provider down');
+        return makeResponse('Working response');
+      });
+
+    const steps: CompositionStep[] = [
+      { name: 'good', provider: 'working' },
+      { name: 'bad', provider: 'failing' },
+    ];
+
+    const result = await composer.execute(makeCtx(), steps, callProvider);
+
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps.find((s) => s.name === 'good')!.status).toBe('success');
+    expect(result.steps.find((s) => s.name === 'bad')!.status).toBe('error');
+    expect(result.finalResponse).toBeDefined();
+  });
+
+  it('throws when too few forks succeed', async () => {
+    const composer = new ForkJoinComposer({ merge: 'concatenate', minSuccessful: 2 });
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'failing') throw new Error('Provider down');
+        return makeResponse('OK');
+      });
+
+    const steps: CompositionStep[] = [
+      { name: 'good', provider: 'working' },
+      { name: 'bad', provider: 'failing' },
+    ];
+
+    await expect(composer.execute(makeCtx(), steps, callProvider)).rejects.toThrow(
+      /only 1\/2 forks succeeded/,
+    );
+  });
+
+  it('vote strategy picks most common response', async () => {
+    const composer = new ForkJoinComposer({ merge: 'vote' });
+    const callProvider: CallProviderFn = vi.fn()
+      .mockResolvedValueOnce(makeResponse('4'))
+      .mockResolvedValueOnce(makeResponse('4'))
+      .mockResolvedValueOnce(makeResponse('5'));
+
+    const steps: CompositionStep[] = [
+      { name: 'a', provider: 'p1' },
+      { name: 'b', provider: 'p2' },
+      { name: 'c', provider: 'p3' },
+    ];
+
+    const result = await composer.execute(makeCtx(), steps, callProvider);
+    expect(result.finalResponse!.content[0]).toMatchObject({ type: 'text', text: '4' });
+  });
+
+  it('best-of strategy calls judge model', async () => {
+    const composer = new ForkJoinComposer({
+      merge: 'best-of',
+      mergeProvider: 'judge',
+      mergeModel: 'gpt-4-judge',
+    });
+
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'judge') return makeResponse('The best answer is 4.');
+        if (provider === 'p1') return makeResponse('I think 4');
+        return makeResponse('Maybe 4?');
+      });
+
+    const steps: CompositionStep[] = [
+      { name: 'a', provider: 'p1' },
+      { name: 'b', provider: 'p2' },
+    ];
+
+    const result = await composer.execute(makeCtx(), steps, callProvider);
+
+    // 2 fork calls + 1 judge call
+    expect(callProvider).toHaveBeenCalledTimes(3);
+    expect(result.finalResponse!.content[0]).toMatchObject({
+      type: 'text',
+      text: 'The best answer is 4.',
+    });
+  });
+
+  it('best-of requires mergeProvider', async () => {
+    const composer = new ForkJoinComposer({ merge: 'best-of' });
+    const steps: CompositionStep[] = [{ name: 'a', provider: 'p1' }];
+
+    await expect(composer.execute(makeCtx(), steps, vi.fn())).rejects.toThrow(
+      /mergeProvider/,
+    );
+  });
+
+  it('rejects empty steps', async () => {
+    const composer = new ForkJoinComposer();
+    await expect(composer.execute(makeCtx(), [], vi.fn())).rejects.toThrow(
+      /at least one step/,
+    );
+  });
+
+  it('respects timeout budget', async () => {
+    const composer = new ForkJoinComposer({ merge: 'concatenate' });
+    // Create context with 1ms timeout — will expire immediately
+    const ctx = makeCtx(1);
+    // Burn the budget
+    await new Promise((r) => setTimeout(r, 5));
+
+    const callProvider: CallProviderFn = vi.fn().mockResolvedValue(makeResponse('OK'));
+    const steps: CompositionStep[] = [{ name: 'a', provider: 'p1' }];
+
+    // Should still return (error status on step) but with minSuccessful=1, it throws
+    await expect(composer.execute(ctx, steps, callProvider)).rejects.toThrow();
+  });
+});

--- a/src/compose/fork-join.ts
+++ b/src/compose/fork-join.ts
@@ -1,0 +1,311 @@
+/**
+ * Fork-Join Composer — parallel fan-out with configurable merge.
+ *
+ * Fans out to N providers via Promise.allSettled, each with a sliced budget.
+ * Merge strategies: best-of (judge model picks), concatenate, vote, custom.
+ */
+
+import type {
+  CallProviderFn,
+  Composer,
+  CompositionResult,
+  CompositionStep,
+  StepResult,
+} from '../core/composer.js';
+import type { PipelineContext } from '../core/context.js';
+import type { CanonicalResponse, ContentBlock } from '../core/types.js';
+import { PipelineError } from '../core/types.js';
+
+// ─── Merge Strategy Types ───
+
+export type MergeStrategy = 'best-of' | 'concatenate' | 'vote' | 'custom';
+
+export interface ForkJoinOptions {
+  /** How to merge the fork results. Default: 'concatenate' */
+  merge: MergeStrategy;
+  /** Model/provider for the judge when using best-of. Required for 'best-of'. */
+  mergeModel?: string;
+  /** Provider name for the merge model */
+  mergeProvider?: string;
+  /** Minimum number of successful forks to proceed. Default: 1 */
+  minSuccessful?: number;
+  /** Custom merge function for 'custom' strategy */
+  customMerge?: (results: StepResult[], ctx: PipelineContext) => string;
+}
+
+/** Extract text from content blocks */
+function extractText(content: ContentBlock[]): string {
+  return content
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n');
+}
+
+/** Build the judge prompt for best-of strategy */
+function buildJudgePrompt(results: StepResult[], originalContent: string): string {
+  const candidates = results
+    .filter((r) => r.status === 'success')
+    .map((r, i) => `--- Candidate ${i + 1} (${r.provider}) ---\n${r.content}`)
+    .join('\n\n');
+
+  return (
+    `You are a judge evaluating multiple AI responses to the same prompt.\n\n` +
+    `Original prompt:\n${originalContent}\n\n` +
+    `${candidates}\n\n` +
+    `Select the best response. Reply with ONLY the full text of the best candidate, ` +
+    `with no additional commentary or explanation.`
+  );
+}
+
+/** Merge via simple vote — pick the most common response (by normalized text) */
+function mergeByVote(results: StepResult[]): string {
+  const successful = results.filter((r) => r.status === 'success');
+  if (successful.length === 0) return '';
+
+  // Count normalized responses
+  const counts = new Map<string, { count: number; original: string }>();
+  for (const r of successful) {
+    const normalized = r.content.trim().toLowerCase();
+    const existing = counts.get(normalized);
+    if (existing) {
+      existing.count++;
+    } else {
+      counts.set(normalized, { count: 1, original: r.content });
+    }
+  }
+
+  // Return the response with highest count
+  let best = { count: 0, original: '' };
+  for (const entry of counts.values()) {
+    if (entry.count > best.count) best = entry;
+  }
+  return best.original;
+}
+
+export class ForkJoinComposer implements Composer {
+  readonly type = 'fork-join';
+  private readonly options: ForkJoinOptions;
+
+  constructor(options: Partial<ForkJoinOptions> = {}) {
+    this.options = {
+      merge: options.merge ?? 'concatenate',
+      mergeModel: options.mergeModel,
+      mergeProvider: options.mergeProvider,
+      minSuccessful: options.minSuccessful ?? 1,
+      customMerge: options.customMerge,
+    };
+  }
+
+  async execute(
+    ctx: PipelineContext,
+    steps: CompositionStep[],
+    callProvider: CallProviderFn,
+  ): Promise<CompositionResult> {
+    const totalStart = Date.now();
+
+    if (steps.length === 0) {
+      throw new PipelineError(
+        'Fork-join requires at least one step',
+        'invalid_request',
+        'fork_join',
+        400,
+      );
+    }
+
+    if (this.options.merge === 'best-of' && !this.options.mergeProvider) {
+      throw new PipelineError(
+        'best-of merge strategy requires mergeProvider',
+        'invalid_request',
+        'fork_join',
+        400,
+      );
+    }
+
+    // ─── Fan-out: execute all steps in parallel ───
+    ctx.log.info(`Fork-join fanning out to ${steps.length} providers`, {
+      merge: this.options.merge,
+      minSuccessful: this.options.minSuccessful,
+    });
+
+    const forkPromises = steps.map(async (step): Promise<StepResult> => {
+      const stepStart = Date.now();
+
+      if (!ctx.timeout.hasTime()) {
+        return {
+          name: step.name,
+          provider: step.provider,
+          content: '',
+          durationMs: 0,
+          status: 'error',
+          error: 'Timeout budget exhausted before fork started',
+        };
+      }
+
+      const stepBudget = ctx.timeout.slice(step.timeout);
+
+      try {
+        const request = {
+          ...ctx.original,
+          model: step.model ?? ctx.original.model,
+          systemPrompt: step.systemPrompt ?? ctx.original.systemPrompt,
+          stream: false as const,
+        };
+
+        const response = await callProvider(request, step.provider, stepBudget, false);
+        const content = extractText(response.content);
+
+        return {
+          name: step.name,
+          provider: step.provider,
+          content,
+          durationMs: Date.now() - stepStart,
+          status: 'success',
+        };
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        ctx.log.warn(`Fork "${step.name}" failed`, { error: errMsg, provider: step.provider });
+
+        return {
+          name: step.name,
+          provider: step.provider,
+          content: step.defaultContent ?? '',
+          durationMs: Date.now() - stepStart,
+          status: step.onError === 'default' ? 'defaulted' : 'error',
+          error: errMsg,
+        };
+      }
+    });
+
+    const settled = await Promise.allSettled(forkPromises);
+    const completedSteps: StepResult[] = settled.map((s) =>
+      s.status === 'fulfilled'
+        ? s.value
+        : {
+            name: 'unknown',
+            provider: 'unknown',
+            content: '',
+            durationMs: 0,
+            status: 'error' as const,
+            error: s.reason instanceof Error ? s.reason.message : String(s.reason),
+          },
+    );
+
+    // ─── Check minimum successful threshold ───
+    const successCount = completedSteps.filter(
+      (s) => s.status === 'success' || s.status === 'defaulted',
+    ).length;
+
+    if (successCount < (this.options.minSuccessful ?? 1)) {
+      const errors = completedSteps
+        .filter((s) => s.status === 'error')
+        .map((s) => `${s.provider}: ${s.error}`)
+        .join('; ');
+
+      throw new PipelineError(
+        `Fork-join: only ${successCount}/${this.options.minSuccessful} forks succeeded. Errors: ${errors}`,
+        'server_error',
+        'fork_join',
+        502,
+      );
+    }
+
+    // ─── Merge phase ───
+    const mergedContent = await this.merge(completedSteps, ctx, callProvider);
+    const totalDurationMs = Date.now() - totalStart;
+
+    ctx.log.info('Fork-join complete', {
+      forks: steps.length,
+      successful: successCount,
+      merge: this.options.merge,
+      totalDurationMs,
+    });
+
+    // Build a synthetic final response
+    const finalResponse: CanonicalResponse = {
+      id: `fj-${ctx.id}`,
+      model: this.options.mergeModel ?? ctx.original.model,
+      content: [{ type: 'text', text: mergedContent }],
+      stopReason: 'end',
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      },
+    };
+
+    return {
+      steps: completedSteps,
+      finalResponse,
+      totalDurationMs,
+    };
+  }
+
+  private async merge(
+    results: StepResult[],
+    ctx: PipelineContext,
+    callProvider: CallProviderFn,
+  ): Promise<string> {
+    const successful = results.filter((r) => r.status === 'success' || r.status === 'defaulted');
+
+    switch (this.options.merge) {
+      case 'concatenate': {
+        return successful.map((r) => `[${r.provider}]\n${r.content}`).join('\n\n');
+      }
+
+      case 'vote': {
+        return mergeByVote(results);
+      }
+
+      case 'best-of': {
+        if (successful.length === 1) return successful[0].content;
+
+        // Extract the original user message for context
+        const lastUserMsg = ctx.original.messages
+          .filter((m) => m.role === 'user')
+          .pop();
+        const originalContent =
+          typeof lastUserMsg?.content === 'string'
+            ? lastUserMsg.content
+            : lastUserMsg
+              ? extractText(lastUserMsg.content as ContentBlock[])
+              : '';
+
+        const judgePrompt = buildJudgePrompt(results, originalContent);
+        const judgeBudget = ctx.timeout.slice();
+
+        const judgeResponse = await callProvider(
+          {
+            model: this.options.mergeModel ?? ctx.original.model,
+            messages: [{ role: 'user', content: judgePrompt }],
+            stream: false,
+          },
+          this.options.mergeProvider!,
+          judgeBudget,
+          false,
+        );
+
+        return extractText(judgeResponse.content);
+      }
+
+      case 'custom': {
+        if (!this.options.customMerge) {
+          throw new PipelineError(
+            'custom merge strategy requires customMerge function',
+            'invalid_request',
+            'fork_join',
+            400,
+          );
+        }
+        return this.options.customMerge(results, ctx);
+      }
+
+      default:
+        throw new PipelineError(
+          `Unknown merge strategy: ${this.options.merge}`,
+          'invalid_request',
+          'fork_join',
+          400,
+        );
+    }
+  }
+}

--- a/src/compose/index.ts
+++ b/src/compose/index.ts
@@ -1,2 +1,7 @@
 export { ChainComposer } from './chain.js';
+export { ForkJoinComposer, type ForkJoinOptions, type MergeStrategy } from './fork-join.js';
 export { resolveTemplate, type TemplateContext } from './template.js';
+export {
+  ThinkingWrapperComposer,
+  type ThinkingWrapperOptions,
+} from './thinking-wrapper.js';

--- a/src/compose/thinking-wrapper.test.ts
+++ b/src/compose/thinking-wrapper.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CallProviderFn } from '../core/composer.js';
+import { PipelineContext } from '../core/context.js';
+import { createTimeoutBudget } from '../core/timeout.js';
+import type { CanonicalResponse, ResolvedConfig } from '../core/types.js';
+import { ThinkingWrapperComposer } from './thinking-wrapper.js';
+
+function makeConfig(): ResolvedConfig {
+  return {
+    port: 3000,
+    logLevel: 'info',
+    requestTimeout: 30_000,
+    providers: {},
+    routes: [],
+  };
+}
+
+function makeResponse(
+  content: string,
+  model = 'gpt-4',
+  usage = { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+): CanonicalResponse {
+  return {
+    id: 'resp-1',
+    model,
+    content: [{ type: 'text', text: content }],
+    stopReason: 'end',
+    usage,
+  };
+}
+
+function makeThinkingResponse(thinking: string, text: string): CanonicalResponse {
+  return {
+    id: 'resp-1',
+    model: 'claude-3.5',
+    content: [
+      { type: 'thinking', text: thinking },
+      { type: 'text', text },
+    ],
+    stopReason: 'end',
+    usage: { inputTokens: 10, outputTokens: 50, totalTokens: 60 },
+  };
+}
+
+function makeCtx(timeout?: number): PipelineContext {
+  return new PipelineContext({
+    request: {
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Explain quantum computing.' }],
+      systemPrompt: 'You are a physicist.',
+    },
+    config: makeConfig(),
+    timeout: createTimeoutBudget(timeout ?? 30_000),
+  });
+}
+
+describe('ThinkingWrapperComposer', () => {
+  it('has type "thinking-wrapper"', () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+    });
+    expect(composer.type).toBe('thinking-wrapper');
+  });
+
+  it('injects reasoning from thinker into executor', async () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+    });
+
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'anthropic') {
+          return makeResponse('Step 1: quantum bits. Step 2: superposition.', 'claude-3.5');
+        }
+        return makeResponse('Quantum computing uses qubits...', 'gpt-4');
+      });
+
+    const result = await composer.execute(makeCtx(), [], callProvider);
+
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].name).toBe('thinker');
+    expect(result.steps[0].status).toBe('success');
+    expect(result.steps[1].name).toBe('executor');
+    expect(result.steps[1].status).toBe('success');
+    expect(result.finalResponse).toBeDefined();
+    expect(result.finalResponse!.content.some((b) => b.type === 'text')).toBe(true);
+
+    // Verify executor received the reasoning in its input
+    const executorCall = (callProvider as ReturnType<typeof vi.fn>).mock.calls[1];
+    const executorReq = executorCall[0];
+    expect(executorReq.messages[0].content).toContain('Step 1: quantum bits');
+  });
+
+  it('extracts thinking blocks when present', async () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+      includeThinking: true,
+    });
+
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'anthropic') {
+          return makeThinkingResponse('Deep analysis here', 'Summary text');
+        }
+        return makeResponse('Final answer based on analysis.');
+      });
+
+    const result = await composer.execute(makeCtx(), [], callProvider);
+
+    // Should include thinking block in final response
+    expect(result.finalResponse!.content.some((b) => b.type === 'thinking')).toBe(true);
+    const thinkingBlock = result.finalResponse!.content.find((b) => b.type === 'thinking');
+    expect(thinkingBlock).toMatchObject({ type: 'thinking', text: 'Deep analysis here' });
+
+    // Executor should have received the thinking content (from thinking block)
+    const executorCall = (callProvider as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(executorCall[0].messages[0].content).toContain('Deep analysis here');
+  });
+
+  it('excludes thinking from response by default', async () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+      includeThinking: false,
+    });
+
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'anthropic') return makeThinkingResponse('Hidden reasoning', 'Surface');
+        return makeResponse('Public answer.');
+      });
+
+    const result = await composer.execute(makeCtx(), [], callProvider);
+    expect(result.finalResponse!.content.every((b) => b.type !== 'thinking')).toBe(true);
+  });
+
+  it('tracks thinking tokens separately in providerExtensions', async () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+    });
+
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'anthropic') {
+          return makeResponse('Reasoning...', 'claude', {
+            inputTokens: 100,
+            outputTokens: 200,
+            totalTokens: 300,
+          });
+        }
+        return makeResponse('Answer.', 'gpt-4', {
+          inputTokens: 50,
+          outputTokens: 30,
+          totalTokens: 80,
+        });
+      });
+
+    const result = await composer.execute(makeCtx(), [], callProvider);
+
+    // Usage should be combined
+    expect(result.finalResponse!.usage.inputTokens).toBe(150);
+    expect(result.finalResponse!.usage.outputTokens).toBe(230);
+    // Thinking tokens tracked separately
+    expect(result.finalResponse!.providerExtensions?.thinkingTokens).toBe(200);
+    expect(result.finalResponse!.providerExtensions?.executorTokens).toBe(30);
+  });
+
+  it('throws when thinker fails', async () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+    });
+
+    const callProvider: CallProviderFn = vi.fn()
+      .mockRejectedValueOnce(new Error('Thinker timeout'));
+
+    await expect(composer.execute(makeCtx(), [], callProvider)).rejects.toThrow(
+      /Thinking step failed/,
+    );
+  });
+
+  it('throws when executor fails', async () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+    });
+
+    const callProvider: CallProviderFn = vi.fn()
+      .mockResolvedValueOnce(makeResponse('Reasoning'))
+      .mockRejectedValueOnce(new Error('Executor overloaded'));
+
+    await expect(composer.execute(makeCtx(), [], callProvider)).rejects.toThrow(
+      /Executor step failed/,
+    );
+  });
+
+  it('uses custom injection template', async () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+      injectionTemplate: 'THINK: {{thinking}}\nACT:',
+    });
+
+    const callProvider: CallProviderFn = vi.fn()
+      .mockImplementation(async (_req, provider) => {
+        if (provider === 'anthropic') return makeResponse('My analysis');
+        return makeResponse('Done');
+      });
+
+    await composer.execute(makeCtx(), [], callProvider);
+
+    const executorCall = (callProvider as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(executorCall[0].messages[0].content).toContain('THINK: My analysis');
+    expect(executorCall[0].messages[0].content).toContain('ACT:');
+  });
+
+  it('respects timeout budget', async () => {
+    const composer = new ThinkingWrapperComposer({
+      thinkerProvider: 'anthropic',
+      executorProvider: 'openai',
+    });
+
+    const ctx = makeCtx(1);
+    await new Promise((r) => setTimeout(r, 5));
+
+    await expect(composer.execute(ctx, [], vi.fn())).rejects.toThrow(/[Tt]imeout/);
+  });
+});

--- a/src/compose/thinking-wrapper.ts
+++ b/src/compose/thinking-wrapper.ts
@@ -1,0 +1,289 @@
+/**
+ * Thinking Wrapper Composer — 2-step chain: reasoning → execution.
+ *
+ * Injects reasoning from a thinking model into a fast executor model,
+ * enabling reasoning-like behavior for non-thinking models.
+ * Thinking tokens are tracked separately for cost analysis.
+ */
+
+import type {
+  CallProviderFn,
+  Composer,
+  CompositionResult,
+  CompositionStep,
+  StepResult,
+} from '../core/composer.js';
+import type { PipelineContext } from '../core/context.js';
+import type { CanonicalResponse, ContentBlock } from '../core/types.js';
+import { PipelineError } from '../core/types.js';
+
+// ─── Configuration ───
+
+export interface ThinkingWrapperOptions {
+  /** Provider name for the reasoning model */
+  thinkerProvider: string;
+  /** Model name for the thinker (e.g. claude-3.5-sonnet with extended thinking) */
+  thinkerModel?: string;
+  /** System prompt for the thinker. Default: generic reasoning prompt. */
+  thinkerPrompt?: string;
+  /** Provider name for the fast executor */
+  executorProvider: string;
+  /** Model name for the executor */
+  executorModel?: string;
+  /** Template for injecting reasoning into the executor prompt.
+   *  Use {{thinking}} as placeholder for the reasoning output.
+   *  Default: "Reasoning:\n{{thinking}}\n\nNow provide your response:" */
+  injectionTemplate?: string;
+  /** Whether to include thinking content in the final response. Default: false */
+  includeThinking?: boolean;
+  /** Per-step timeout for the thinker in ms */
+  thinkerTimeout?: number;
+  /** Per-step timeout for the executor in ms */
+  executorTimeout?: number;
+}
+
+const DEFAULT_THINKER_PROMPT =
+  'Think through this problem step by step. Show your reasoning process clearly. ' +
+  'Focus on analysis, edge cases, and the best approach before arriving at a conclusion.';
+
+const DEFAULT_INJECTION_TEMPLATE =
+  'The following reasoning was produced by an analysis step. ' +
+  'Use it to inform your response, but write your answer naturally.\n\n' +
+  'Reasoning:\n{{thinking}}\n\nNow provide your response to the original request:';
+
+/** Extract text from content blocks */
+function extractText(content: ContentBlock[]): string {
+  return content
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n');
+}
+
+/** Extract thinking blocks specifically */
+function extractThinking(content: ContentBlock[]): string {
+  return content
+    .filter((b): b is { type: 'thinking'; text: string } => b.type === 'thinking')
+    .map((b) => b.text)
+    .join('\n');
+}
+
+export class ThinkingWrapperComposer implements Composer {
+  readonly type = 'thinking-wrapper';
+  private readonly options: ThinkingWrapperOptions;
+
+  constructor(options: ThinkingWrapperOptions) {
+    this.options = {
+      ...options,
+      thinkerPrompt: options.thinkerPrompt ?? DEFAULT_THINKER_PROMPT,
+      injectionTemplate: options.injectionTemplate ?? DEFAULT_INJECTION_TEMPLATE,
+      includeThinking: options.includeThinking ?? false,
+    };
+  }
+
+  async execute(
+    ctx: PipelineContext,
+    _steps: CompositionStep[],
+    callProvider: CallProviderFn,
+  ): Promise<CompositionResult> {
+    const totalStart = Date.now();
+    const completedSteps: StepResult[] = [];
+
+    // ─── Step 1: Thinker ───
+    ctx.log.info('Thinking wrapper: starting thinker step', {
+      provider: this.options.thinkerProvider,
+      model: this.options.thinkerModel,
+    });
+
+    const thinkerStart = Date.now();
+    let thinkingContent = '';
+    let thinkerUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+    if (!ctx.timeout.hasTime()) {
+      throw new PipelineError(
+        'Timeout budget exhausted before thinking step',
+        'timeout',
+        'thinking_wrapper',
+        504,
+        true,
+      );
+    }
+
+    const thinkerBudget = ctx.timeout.slice(this.options.thinkerTimeout);
+
+    try {
+      const thinkerRequest = {
+        model: this.options.thinkerModel ?? ctx.original.model,
+        messages: [...ctx.original.messages],
+        systemPrompt: this.options.thinkerPrompt,
+        temperature: ctx.original.temperature,
+        maxTokens: ctx.original.maxTokens,
+        topP: ctx.original.topP,
+        stream: false as const,
+      };
+
+      const thinkerResponse = await callProvider(
+        thinkerRequest,
+        this.options.thinkerProvider,
+        thinkerBudget,
+        false,
+      );
+
+      // Extract thinking blocks if present; fall back to text content
+      thinkingContent = extractThinking(thinkerResponse.content) || extractText(thinkerResponse.content);
+      thinkerUsage = thinkerResponse.usage;
+
+      completedSteps.push({
+        name: 'thinker',
+        provider: this.options.thinkerProvider,
+        content: thinkingContent,
+        durationMs: Date.now() - thinkerStart,
+        status: 'success',
+      });
+
+      ctx.log.info('Thinking wrapper: thinker complete', {
+        thinkingLength: thinkingContent.length,
+        durationMs: Date.now() - thinkerStart,
+        thinkingTokens: thinkerUsage.outputTokens,
+      });
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      completedSteps.push({
+        name: 'thinker',
+        provider: this.options.thinkerProvider,
+        content: '',
+        durationMs: Date.now() - thinkerStart,
+        status: 'error',
+        error: errMsg,
+      });
+
+      throw new PipelineError(
+        `Thinking step failed: ${errMsg}`,
+        'server_error',
+        'thinking_wrapper.thinker',
+        502,
+      );
+    }
+
+    // ─── Step 2: Executor with injected reasoning ───
+    ctx.log.info('Thinking wrapper: starting executor step', {
+      provider: this.options.executorProvider,
+      model: this.options.executorModel,
+    });
+
+    const executorStart = Date.now();
+
+    if (!ctx.timeout.hasTime()) {
+      throw new PipelineError(
+        'Timeout budget exhausted before executor step',
+        'timeout',
+        'thinking_wrapper',
+        504,
+        true,
+      );
+    }
+
+    const executorBudget = ctx.timeout.slice(this.options.executorTimeout);
+
+    // Inject the reasoning into the executor's messages
+    const injectedContent = this.options.injectionTemplate!.replace(
+      /\{\{thinking\}\}/g,
+      thinkingContent,
+    );
+
+    // Get the original user message
+    const originalMessages = ctx.original.messages;
+    const lastUserMsg = [...originalMessages].reverse().find((m) => m.role === 'user');
+    const lastUserText =
+      typeof lastUserMsg?.content === 'string'
+        ? lastUserMsg.content
+        : lastUserMsg
+          ? extractText(lastUserMsg.content as ContentBlock[])
+          : '';
+
+    const executorRequest = {
+      model: this.options.executorModel ?? ctx.original.model,
+      messages: [
+        // Provide context: system-like injection of reasoning, then original user message
+        { role: 'user' as const, content: `${injectedContent}\n\nOriginal request: ${lastUserText}` },
+      ],
+      systemPrompt: ctx.original.systemPrompt,
+      temperature: ctx.original.temperature,
+      maxTokens: ctx.original.maxTokens,
+      topP: ctx.original.topP,
+      stream: false as const,
+    };
+
+    try {
+      const executorResponse = await callProvider(
+        executorRequest,
+        this.options.executorProvider,
+        executorBudget,
+        false,
+      );
+
+      const executorContent = extractText(executorResponse.content);
+
+      completedSteps.push({
+        name: 'executor',
+        provider: this.options.executorProvider,
+        content: executorContent,
+        durationMs: Date.now() - executorStart,
+        status: 'success',
+      });
+
+      ctx.log.info('Thinking wrapper: executor complete', {
+        contentLength: executorContent.length,
+        durationMs: Date.now() - executorStart,
+      });
+
+      // ─── Build final response ───
+      const finalContent: ContentBlock[] = [];
+
+      // Optionally include thinking in response
+      if (this.options.includeThinking && thinkingContent) {
+        finalContent.push({ type: 'thinking', text: thinkingContent });
+      }
+
+      finalContent.push(...executorResponse.content.filter((b) => b.type === 'text'));
+
+      const finalResponse: CanonicalResponse = {
+        id: `tw-${ctx.id}`,
+        model: executorResponse.model,
+        content: finalContent,
+        stopReason: executorResponse.stopReason,
+        usage: {
+          inputTokens: thinkerUsage.inputTokens + executorResponse.usage.inputTokens,
+          outputTokens: thinkerUsage.outputTokens + executorResponse.usage.outputTokens,
+          totalTokens: thinkerUsage.totalTokens + executorResponse.usage.totalTokens,
+        },
+        providerExtensions: {
+          thinkingTokens: thinkerUsage.outputTokens,
+          executorTokens: executorResponse.usage.outputTokens,
+        },
+      };
+
+      return {
+        steps: completedSteps,
+        finalResponse,
+        totalDurationMs: Date.now() - totalStart,
+      };
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      completedSteps.push({
+        name: 'executor',
+        provider: this.options.executorProvider,
+        content: '',
+        durationMs: Date.now() - executorStart,
+        status: 'error',
+        error: errMsg,
+      });
+
+      throw new PipelineError(
+        `Executor step failed: ${errMsg}`,
+        'server_error',
+        'thinking_wrapper.executor',
+        502,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds two new composers building on the #11 composition framework:

### Fork-Join Composer (`src/compose/fork-join.ts`)
- Parallel fan-out to N providers via `Promise.allSettled`, each with sliced timeout budget
- Merge strategies: `best-of` (judge model picks), `concatenate`, `vote`, `custom`
- Configurable merge model/provider and minimum successful forks threshold
- Graceful partial failure handling

### Thinking Wrapper Composer (`src/compose/thinking-wrapper.ts`)
- Specialized 2-step chain: reasoning model → fast executor with reasoning injected
- Extracts thinking blocks when present, falls back to text content
- Configurable thinker prompt and injection template (`{{thinking}}` placeholder)
- Thinking tokens tracked separately in `providerExtensions` for cost analysis
- Option to include/exclude thinking blocks in final response

### Tests
- 9 fork-join tests: parallel execution, merge strategies, partial failures, timeout budgets
- 9 thinking wrapper tests: injection, thinking block extraction, token tracking, custom templates

Addresses issue #12