### PR TITLE
feat: circuit breaker + multi-IP egress

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -51,6 +51,31 @@ export const StoreConfigSchema = z.object({
 });
 export type StoreConfig = z.infer<typeof StoreConfigSchema>;
 
+export const EgressIpSchema = z.object({
+  address: z.string(),
+  weight: z.number().positive().optional(),
+  providers: z.array(z.string()).optional(),
+});
+
+export const EgressProxySchema = z.object({
+  url: z.string(),
+  providers: z.array(z.string()).optional(),
+});
+
+export const EgressConfigSchema = z.object({
+  ips: z.array(EgressIpSchema).optional(),
+  proxies: z.array(EgressProxySchema).optional(),
+  strategy: z.enum(['round-robin', 'random', 'least-recently-used', 'weighted-round-robin']).default('round-robin'),
+});
+export type EgressConfig = z.infer<typeof EgressConfigSchema>;
+
+export const CircuitBreakerConfigSchema = z.object({
+  failureThreshold: z.number().positive().default(5),
+  resetTimeoutMs: z.number().positive().default(30_000),
+  halfOpenRequests: z.number().positive().default(1),
+});
+export type CircuitBreakerConfig = z.infer<typeof CircuitBreakerConfigSchema>;
+
 // ── Root schema ──
 
 const ServerConfigSchema = z.object({
@@ -72,6 +97,8 @@ export const PrismPipeConfigSchema = z.object({
   rateLimits: RateLimitConfigSchema.optional(),
   logging: nestedWithDefaults(LoggingConfigSchema),
   store: nestedWithDefaults(StoreConfigSchema),
+  egress: EgressConfigSchema.optional(),
+  circuitBreaker: CircuitBreakerConfigSchema.optional(),
 });
 
 export type PrismPipeConfig = z.infer<typeof PrismPipeConfigSchema>;

--- a/src/fallback/chain.ts
+++ b/src/fallback/chain.ts
@@ -8,6 +8,7 @@ import {
   type ProviderStreamResult,
 } from '../proxy/provider.js';
 import type { ProviderTransformer } from '../proxy/transform-registry.js';
+import type { CircuitBreakerRegistry } from './circuit-breaker.js';
 
 export interface FallbackChainOptions {
   providers: Array<{
@@ -20,6 +21,8 @@ export interface FallbackChainOptions {
   log: ScopedLogger;
   maxRetries?: number;
   baseBackoffMs?: number;
+  /** Optional circuit breaker registry — tripped providers are skipped */
+  circuitBreakers?: CircuitBreakerRegistry;
 }
 
 async function sleep(ms: number): Promise<void> {
@@ -33,36 +36,49 @@ async function sleep(ms: number): Promise<void> {
 export async function executeFallbackChain(
   opts: FallbackChainOptions
 ): Promise<ProviderCallResult | ProviderStreamResult> {
-  const { providers, body, stream, timeout, log, maxRetries = 2, baseBackoffMs = 500 } = opts;
+  const { providers, body, stream, timeout, log, maxRetries = 2, baseBackoffMs = 500, circuitBreakers } = opts;
   const errors: Array<{ provider: string; error: PipelineError }> = [];
 
   for (const { config, transformer } of providers) {
     if (!timeout.hasTime()) break;
 
+    // Skip tripped providers
+    if (circuitBreakers && !circuitBreakers.isAvailable(config.name)) {
+      log.warn(`Skipping provider ${config.name} — circuit breaker is open`);
+      continue;
+    }
+
+    const breaker = circuitBreakers?.get(config.name);
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (!timeout.hasTime()) break;
 
       try {
+        let result: ProviderCallResult | ProviderStreamResult;
         if (stream) {
-          return await callProviderStream({
+          result = await callProviderStream({
+            providerConfig: config,
+            transformer,
+            body,
+            timeout,
+          });
+        } else {
+          result = await callProvider({
             providerConfig: config,
             transformer,
             body,
             timeout,
           });
         }
-        return await callProvider({
-          providerConfig: config,
-          transformer,
-          body,
-          timeout,
-        });
+        breaker?.recordSuccess();
+        return result;
       } catch (err) {
         const pErr =
           err instanceof PipelineError
             ? err
             : new PipelineError(String(err), 'unknown', config.name, 500, false);
 
+        breaker?.recordFailure();
         errors.push({ provider: config.name, error: pErr });
         log.warn(`Provider ${config.name} failed (attempt ${attempt + 1})`, {
           code: pErr.code,

--- a/src/fallback/circuit-breaker.test.ts
+++ b/src/fallback/circuit-breaker.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CircuitBreaker, CircuitBreakerRegistry } from './circuit-breaker.js';
+
+describe('CircuitBreaker', () => {
+  let cb: CircuitBreaker;
+
+  beforeEach(() => {
+    cb = new CircuitBreaker('test-provider', {
+      failureThreshold: 3,
+      resetTimeoutMs: 100,
+      halfOpenRequests: 1,
+    });
+  });
+
+  it('starts in closed state', () => {
+    expect(cb.getState()).toBe('closed');
+    expect(cb.allowRequest()).toBe(true);
+  });
+
+  it('trips after N consecutive failures', () => {
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe('closed');
+    cb.recordFailure(); // 3rd = threshold
+    expect(cb.getState()).toBe('open');
+    expect(cb.allowRequest()).toBe(false);
+  });
+
+  it('resets failure count on success', () => {
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordSuccess(); // resets counter
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe('closed'); // only 2 consecutive, not 3
+  });
+
+  it('transitions to half-open after reset timeout', async () => {
+    // Trip it
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe('open');
+
+    // Wait for reset timeout
+    await new Promise((r) => setTimeout(r, 120));
+    expect(cb.getState()).toBe('half-open');
+  });
+
+  it('half-open allows limited test requests', async () => {
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordFailure();
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(cb.getState()).toBe('half-open');
+    expect(cb.allowRequest()).toBe(true); // 1 test request
+    expect(cb.allowRequest()).toBe(false); // no more
+  });
+
+  it('half-open → closed on success', async () => {
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordFailure();
+    await new Promise((r) => setTimeout(r, 120));
+
+    cb.allowRequest(); // consume the test slot
+    cb.recordSuccess();
+    expect(cb.getState()).toBe('closed');
+  });
+
+  it('half-open → open on failure', async () => {
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordFailure();
+    await new Promise((r) => setTimeout(r, 120));
+
+    cb.allowRequest();
+    cb.recordFailure();
+    expect(cb.getState()).toBe('open');
+  });
+
+  it('emits metrics on state changes and rejections', () => {
+    const counter = vi.fn();
+    const metrics = { counter, histogram: vi.fn(), gauge: vi.fn() };
+    const cb2 = new CircuitBreaker('metriced', { failureThreshold: 2, metrics });
+
+    cb2.recordFailure();
+    cb2.recordFailure(); // trips
+    expect(counter).toHaveBeenCalledWith('prism.circuit_breaker.state_change', 1, {
+      provider: 'metriced',
+      from: 'closed',
+      to: 'open',
+    });
+
+    cb2.allowRequest(); // rejected
+    expect(counter).toHaveBeenCalledWith('prism.circuit_breaker.rejected', 1, {
+      provider: 'metriced',
+    });
+  });
+
+  it('reset() restores to closed', () => {
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe('open');
+    cb.reset();
+    expect(cb.getState()).toBe('closed');
+    expect(cb.allowRequest()).toBe(true);
+  });
+});
+
+describe('CircuitBreakerRegistry', () => {
+  it('creates and caches breakers per provider', () => {
+    const reg = new CircuitBreakerRegistry({ failureThreshold: 2 });
+    const a = reg.get('openai');
+    const b = reg.get('openai');
+    expect(a).toBe(b);
+    expect(reg.get('anthropic')).not.toBe(a);
+  });
+
+  it('isAvailable reflects breaker state', () => {
+    const reg = new CircuitBreakerRegistry({ failureThreshold: 2 });
+    expect(reg.isAvailable('openai')).toBe(true);
+    reg.get('openai').recordFailure();
+    reg.get('openai').recordFailure();
+    expect(reg.isAvailable('openai')).toBe(false);
+  });
+});

--- a/src/fallback/circuit-breaker.ts
+++ b/src/fallback/circuit-breaker.ts
@@ -1,0 +1,158 @@
+import type { MetricsEmitter } from '../core/types.js';
+
+export type CircuitState = 'closed' | 'open' | 'half-open';
+
+export interface CircuitBreakerOptions {
+  /** Number of consecutive failures to trip the breaker. Default: 5 */
+  failureThreshold?: number;
+  /** How long (ms) to stay open before entering half-open. Default: 30_000 */
+  resetTimeoutMs?: number;
+  /** Number of test requests allowed in half-open state. Default: 1 */
+  halfOpenRequests?: number;
+  /** Optional metrics emitter */
+  metrics?: MetricsEmitter;
+}
+
+/**
+ * Per-provider circuit breaker with three states:
+ *  - closed: normal operation
+ *  - open: reject immediately (provider is down)
+ *  - half-open: allow a few test requests
+ */
+export class CircuitBreaker {
+  readonly provider: string;
+  private state: CircuitState = 'closed';
+  private consecutiveFailures = 0;
+  private halfOpenSuccesses = 0;
+  private halfOpenAttempts = 0;
+  private openedAt = 0;
+
+  private readonly failureThreshold: number;
+  private readonly resetTimeoutMs: number;
+  private readonly halfOpenRequests: number;
+  private readonly metrics?: MetricsEmitter;
+
+  constructor(provider: string, opts: CircuitBreakerOptions = {}) {
+    this.provider = provider;
+    this.failureThreshold = opts.failureThreshold ?? 5;
+    this.resetTimeoutMs = opts.resetTimeoutMs ?? 30_000;
+    this.halfOpenRequests = opts.halfOpenRequests ?? 1;
+    this.metrics = opts.metrics;
+  }
+
+  /** Current breaker state */
+  getState(): CircuitState {
+    // Check if open → half-open transition is due
+    if (this.state === 'open' && Date.now() - this.openedAt >= this.resetTimeoutMs) {
+      this.transitionTo('half-open');
+    }
+    return this.state;
+  }
+
+  /**
+   * Returns true if a request is allowed through.
+   * In open state, rejects immediately. In half-open, allows limited test requests.
+   */
+  allowRequest(): boolean {
+    const current = this.getState();
+    if (current === 'closed') return true;
+    if (current === 'open') {
+      this.metrics?.counter('prism.circuit_breaker.rejected', 1, { provider: this.provider });
+      return false;
+    }
+    // half-open: allow up to halfOpenRequests test requests
+    if (this.halfOpenAttempts < this.halfOpenRequests) {
+      this.halfOpenAttempts++;
+      return true;
+    }
+    this.metrics?.counter('prism.circuit_breaker.rejected', 1, { provider: this.provider });
+    return false;
+  }
+
+  /** Record a successful request */
+  recordSuccess(): void {
+    if (this.state === 'half-open') {
+      this.halfOpenSuccesses++;
+      if (this.halfOpenSuccesses >= this.halfOpenRequests) {
+        this.transitionTo('closed');
+      }
+      return;
+    }
+    // In closed state, reset failure counter
+    this.consecutiveFailures = 0;
+  }
+
+  /** Record a failed request */
+  recordFailure(): void {
+    if (this.state === 'half-open') {
+      // Any failure in half-open reopens the circuit
+      this.transitionTo('open');
+      return;
+    }
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= this.failureThreshold) {
+      this.transitionTo('open');
+    }
+  }
+
+  /** Force a state transition (for testing or manual control) */
+  reset(): void {
+    this.transitionTo('closed');
+  }
+
+  private transitionTo(newState: CircuitState): void {
+    const old = this.state;
+    if (old === newState) return;
+
+    this.state = newState;
+    this.metrics?.counter('prism.circuit_breaker.state_change', 1, {
+      provider: this.provider,
+      from: old,
+      to: newState,
+    });
+
+    if (newState === 'open') {
+      this.openedAt = Date.now();
+      this.halfOpenSuccesses = 0;
+      this.halfOpenAttempts = 0;
+    } else if (newState === 'closed') {
+      this.consecutiveFailures = 0;
+      this.halfOpenSuccesses = 0;
+      this.halfOpenAttempts = 0;
+    } else if (newState === 'half-open') {
+      this.halfOpenSuccesses = 0;
+      this.halfOpenAttempts = 0;
+    }
+  }
+}
+
+/**
+ * Registry of circuit breakers keyed by provider name.
+ */
+export class CircuitBreakerRegistry {
+  private readonly breakers = new Map<string, CircuitBreaker>();
+  private readonly defaultOpts: CircuitBreakerOptions;
+
+  constructor(opts: CircuitBreakerOptions = {}) {
+    this.defaultOpts = opts;
+  }
+
+  get(provider: string): CircuitBreaker {
+    let cb = this.breakers.get(provider);
+    if (!cb) {
+      cb = new CircuitBreaker(provider, this.defaultOpts);
+      this.breakers.set(provider, cb);
+    }
+    return cb;
+  }
+
+  /** Check if a provider is available (not tripped) */
+  isAvailable(provider: string): boolean {
+    return this.get(provider).allowRequest();
+  }
+
+  /** Get all breakers for inspection */
+  all(): ReadonlyMap<string, CircuitBreaker> {
+    return this.breakers;
+  }
+}

--- a/src/fallback/index.ts
+++ b/src/fallback/index.ts
@@ -1,2 +1,3 @@
 export { FallbackChain } from "./chain.js";
 export { retryWithBackoff } from "./retry.js";
+export { CircuitBreaker, CircuitBreakerRegistry, type CircuitBreakerOptions, type CircuitState } from "./circuit-breaker.js";

--- a/src/network/agent-factory.ts
+++ b/src/network/agent-factory.ts
@@ -1,0 +1,73 @@
+/**
+ * AgentFactory: create http.Agent / https.Agent bound to specific local addresses
+ * for multi-IP egress. Supports SOCKS5 and HTTP CONNECT proxies.
+ */
+
+import * as http from 'node:http';
+import * as https from 'node:https';
+import type { IpPool } from './ip-pool.js';
+
+export interface AgentFactoryOptions {
+  ipPool: IpPool;
+  /** Keep-alive for outbound connections. Default: true */
+  keepAlive?: boolean;
+  /** Max sockets per host. Default: 10 */
+  maxSockets?: number;
+}
+
+/**
+ * Creates HTTP(S) agents bound to specific local addresses from the IP pool.
+ * Falls back to a default agent when no IP is selected.
+ */
+export class AgentFactory {
+  private readonly ipPool: IpPool;
+  private readonly keepAlive: boolean;
+  private readonly maxSockets: number;
+  private readonly agentCache = new Map<string, http.Agent | https.Agent>();
+
+  constructor(opts: AgentFactoryOptions) {
+    this.ipPool = opts.ipPool;
+    this.keepAlive = opts.keepAlive ?? true;
+    this.maxSockets = opts.maxSockets ?? 10;
+  }
+
+  /**
+   * Get an HTTP agent for the given provider, optionally bound to a local address.
+   * Returns undefined if no special agent is needed (no IPs configured).
+   */
+  getAgent(provider?: string, secure = true): http.Agent | https.Agent | undefined {
+    const ip = this.ipPool.selectIp(provider);
+    if (!ip) return undefined;
+
+    const cacheKey = `${ip.address}:${secure ? 'https' : 'http'}`;
+    const cached = this.agentCache.get(cacheKey);
+    if (cached) return cached;
+
+    const opts = {
+      localAddress: ip.address,
+      keepAlive: this.keepAlive,
+      maxSockets: this.maxSockets,
+    };
+
+    const agent = secure ? new https.Agent(opts) : new http.Agent(opts);
+    this.agentCache.set(cacheKey, agent);
+    return agent;
+  }
+
+  /**
+   * Get the proxy URL for a provider, if configured.
+   */
+  getProxyUrl(provider?: string): string | undefined {
+    return this.ipPool.selectProxy(provider);
+  }
+
+  /**
+   * Destroy all cached agents (for cleanup/shutdown).
+   */
+  destroy(): void {
+    for (const agent of this.agentCache.values()) {
+      agent.destroy();
+    }
+    this.agentCache.clear();
+  }
+}

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -1,0 +1,2 @@
+export { IpPool, type IpEntry, type IpPoolConfig, type ProxyEntry, type SelectionStrategy } from './ip-pool.js';
+export { AgentFactory, type AgentFactoryOptions } from './agent-factory.js';

--- a/src/network/ip-pool.test.ts
+++ b/src/network/ip-pool.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { IpPool } from './ip-pool.js';
+
+describe('IpPool', () => {
+  describe('round-robin', () => {
+    it('cycles through IPs in order', () => {
+      const pool = new IpPool({
+        ips: [
+          { address: '10.0.0.1' },
+          { address: '10.0.0.2' },
+          { address: '10.0.0.3' },
+        ],
+        strategy: 'round-robin',
+      });
+
+      const results = [pool.selectIp(), pool.selectIp(), pool.selectIp(), pool.selectIp()];
+      expect(results.map((r) => r?.address)).toEqual([
+        '10.0.0.1', '10.0.0.2', '10.0.0.3', '10.0.0.1',
+      ]);
+    });
+  });
+
+  describe('weighted-round-robin', () => {
+    it('distributes based on weight', () => {
+      const pool = new IpPool({
+        ips: [
+          { address: '10.0.0.1', weight: 2 },
+          { address: '10.0.0.2', weight: 1 },
+        ],
+        strategy: 'weighted-round-robin',
+      });
+
+      const counts: Record<string, number> = {};
+      for (let i = 0; i < 6; i++) {
+        const ip = pool.selectIp();
+        counts[ip!.address] = (counts[ip!.address] ?? 0) + 1;
+      }
+      // Weight 2 should get ~2x the requests of weight 1
+      expect(counts['10.0.0.1']).toBeGreaterThan(counts['10.0.0.2']!);
+    });
+  });
+
+  describe('per-provider assignment', () => {
+    it('returns only IPs assigned to the provider', () => {
+      const pool = new IpPool({
+        ips: [
+          { address: '10.0.0.1', providers: ['openai'] },
+          { address: '10.0.0.2', providers: ['anthropic'] },
+          { address: '10.0.0.3' }, // available for all
+        ],
+        strategy: 'round-robin',
+      });
+
+      // openai should get .1 and .3
+      const openaiIps = new Set<string>();
+      for (let i = 0; i < 4; i++) {
+        openaiIps.add(pool.selectIp('openai')!.address);
+      }
+      expect(openaiIps).toContain('10.0.0.1');
+      expect(openaiIps).toContain('10.0.0.3');
+      expect(openaiIps).not.toContain('10.0.0.2');
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('deprioritizes rate-limited IPs', () => {
+      const pool = new IpPool({
+        ips: [
+          { address: '10.0.0.1' },
+          { address: '10.0.0.2' },
+        ],
+        strategy: 'round-robin',
+      });
+
+      pool.markRateLimited('10.0.0.1', 60_000);
+
+      // All requests should go to .2
+      const results = new Set<string>();
+      for (let i = 0; i < 4; i++) {
+        results.add(pool.selectIp()!.address);
+      }
+      expect(results).toEqual(new Set(['10.0.0.2']));
+    });
+
+    it('restores IP after rate-limit expires', async () => {
+      const pool = new IpPool({
+        ips: [
+          { address: '10.0.0.1' },
+          { address: '10.0.0.2' },
+        ],
+        strategy: 'round-robin',
+      });
+
+      pool.markRateLimited('10.0.0.1', 50);
+      await new Promise((r) => setTimeout(r, 70));
+
+      const results = new Set<string>();
+      for (let i = 0; i < 4; i++) {
+        results.add(pool.selectIp()!.address);
+      }
+      expect(results).toContain('10.0.0.1');
+    });
+
+    it('clearRateLimit restores IP immediately', () => {
+      const pool = new IpPool({
+        ips: [{ address: '10.0.0.1' }, { address: '10.0.0.2' }],
+        strategy: 'round-robin',
+      });
+
+      pool.markRateLimited('10.0.0.1', 60_000);
+      pool.clearRateLimit('10.0.0.1');
+
+      const results = new Set<string>();
+      for (let i = 0; i < 4; i++) results.add(pool.selectIp()!.address);
+      expect(results).toContain('10.0.0.1');
+    });
+  });
+
+  describe('empty pool', () => {
+    it('returns undefined when no IPs configured', () => {
+      const pool = new IpPool({});
+      expect(pool.selectIp()).toBeUndefined();
+    });
+  });
+
+  describe('proxy selection', () => {
+    it('returns proxy URL for provider', () => {
+      const pool = new IpPool({
+        proxies: [
+          { url: 'socks5://proxy1:1080' },
+          { url: 'http://proxy2:8080', providers: ['openai'] },
+        ],
+      });
+
+      expect(pool.selectProxy()).toBeDefined();
+      // Provider-specific
+      const openaiProxy = pool.selectProxy('openai');
+      expect(openaiProxy).toBeDefined();
+    });
+
+    it('returns undefined when no proxies configured', () => {
+      const pool = new IpPool({});
+      expect(pool.selectProxy()).toBeUndefined();
+    });
+  });
+});

--- a/src/network/ip-pool.ts
+++ b/src/network/ip-pool.ts
@@ -1,0 +1,183 @@
+/**
+ * Multi-IP egress pool: manages available egress IPs with selection strategies,
+ * per-provider assignment, and health tracking.
+ */
+
+export interface IpEntry {
+  address: string;
+  weight?: number;
+  /** Restrict this IP to specific providers */
+  providers?: string[];
+}
+
+export interface ProxyEntry {
+  url: string;
+  /** Restrict this proxy to specific providers */
+  providers?: string[];
+}
+
+export type SelectionStrategy = 'round-robin' | 'random' | 'least-recently-used' | 'weighted-round-robin';
+
+export interface IpPoolConfig {
+  ips?: IpEntry[];
+  proxies?: ProxyEntry[];
+  strategy?: SelectionStrategy;
+}
+
+interface IpState {
+  entry: IpEntry;
+  lastUsedAt: number;
+  rateLimited: boolean;
+  rateLimitedUntil: number;
+  usageCount: number;
+}
+
+/**
+ * Manages a pool of egress IPs with configurable selection strategies.
+ */
+export class IpPool {
+  private readonly ips: IpState[];
+  private readonly proxies: ProxyEntry[];
+  private readonly strategy: SelectionStrategy;
+  private roundRobinIndex = 0;
+  private weightedIndex = 0;
+  private weightedCounter = 0;
+
+  constructor(config: IpPoolConfig = {}) {
+    this.ips = (config.ips ?? []).map((entry) => ({
+      entry,
+      lastUsedAt: 0,
+      rateLimited: false,
+      rateLimitedUntil: 0,
+      usageCount: 0,
+    }));
+    this.proxies = config.proxies ?? [];
+    this.strategy = config.strategy ?? 'round-robin';
+  }
+
+  /** Total number of IPs in the pool */
+  get size(): number {
+    return this.ips.length;
+  }
+
+  /**
+   * Select an egress IP for the given provider.
+   * Returns undefined if no IPs are configured or available.
+   */
+  selectIp(provider?: string): IpEntry | undefined {
+    const candidates = this.getCandidates(provider);
+    if (candidates.length === 0) return undefined;
+
+    const now = Date.now();
+    // Clear expired rate limits
+    for (const c of candidates) {
+      if (c.rateLimited && now >= c.rateLimitedUntil) {
+        c.rateLimited = false;
+      }
+    }
+
+    const healthy = candidates.filter((c) => !c.rateLimited);
+    const pool = healthy.length > 0 ? healthy : candidates; // fallback to all if all rate-limited
+
+    const selected = this.selectByStrategy(pool);
+    if (!selected) return undefined;
+
+    selected.lastUsedAt = now;
+    selected.usageCount++;
+    return selected.entry;
+  }
+
+  /**
+   * Get proxy URL for a given provider, if configured.
+   */
+  selectProxy(provider?: string): string | undefined {
+    if (this.proxies.length === 0) return undefined;
+    const candidates = provider
+      ? this.proxies.filter((p) => !p.providers || p.providers.includes(provider))
+      : this.proxies;
+    if (candidates.length === 0) return undefined;
+    // Simple round-robin for proxies
+    return candidates[Date.now() % candidates.length]?.url;
+  }
+
+  /**
+   * Mark an IP as rate-limited. It will be deprioritized for `durationMs`.
+   */
+  markRateLimited(address: string, durationMs = 60_000): void {
+    const state = this.ips.find((s) => s.entry.address === address);
+    if (state) {
+      state.rateLimited = true;
+      state.rateLimitedUntil = Date.now() + durationMs;
+    }
+  }
+
+  /**
+   * Clear rate-limit status for an IP.
+   */
+  clearRateLimit(address: string): void {
+    const state = this.ips.find((s) => s.entry.address === address);
+    if (state) {
+      state.rateLimited = false;
+      state.rateLimitedUntil = 0;
+    }
+  }
+
+  /** Get all IP entries (for inspection/testing) */
+  getAll(): ReadonlyArray<IpEntry> {
+    return this.ips.map((s) => s.entry);
+  }
+
+  private getCandidates(provider?: string): IpState[] {
+    if (!provider) return [...this.ips];
+    return this.ips.filter(
+      (s) => !s.entry.providers || s.entry.providers.length === 0 || s.entry.providers.includes(provider)
+    );
+  }
+
+  private selectByStrategy(pool: IpState[]): IpState | undefined {
+    if (pool.length === 0) return undefined;
+    if (pool.length === 1) return pool[0];
+
+    switch (this.strategy) {
+      case 'round-robin': {
+        const idx = this.roundRobinIndex % pool.length;
+        this.roundRobinIndex = (this.roundRobinIndex + 1) % pool.length;
+        return pool[idx];
+      }
+
+      case 'random':
+        return pool[Math.floor(Math.random() * pool.length)];
+
+      case 'least-recently-used': {
+        let oldest = pool[0]!;
+        for (let i = 1; i < pool.length; i++) {
+          if (pool[i]!.lastUsedAt < oldest.lastUsedAt) {
+            oldest = pool[i]!;
+          }
+        }
+        return oldest;
+      }
+
+      case 'weighted-round-robin': {
+        // Weighted round-robin: each IP gets turns proportional to its weight
+        const totalWeight = pool.reduce((sum, s) => sum + (s.entry.weight ?? 1), 0);
+        if (totalWeight === 0) return pool[0];
+
+        let remaining = this.weightedCounter % totalWeight;
+        for (const s of pool) {
+          const w = s.entry.weight ?? 1;
+          if (remaining < w) {
+            this.weightedCounter++;
+            return s;
+          }
+          remaining -= w;
+        }
+        this.weightedCounter++;
+        return pool[0];
+      }
+
+      default:
+        return pool[0];
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Addresses issue #15 — adds network resilience with circuit breakers and multi-IP egress.

### Circuit Breaker (`src/fallback/circuit-breaker.ts`)
- Per-provider circuit breaker with three states: closed → open → half-open
- Configurable failure threshold (default 5), reset timeout (default 30s), half-open test requests
- Integrated into fallback chain: tripped providers are automatically skipped
- Metrics emission on state changes and rejections (`prism.circuit_breaker.state_change`, `prism.circuit_breaker.rejected`)
- `CircuitBreakerRegistry` for managing breakers across all providers

### Multi-IP Egress (`src/network/`)
- `IpPool`: manages egress IPs with 4 selection strategies (round-robin, random, LRU, weighted-round-robin)
- Per-provider IP assignment (e.g., restrict certain IPs to OpenAI only)
- IP health tracking: rate-limited IPs are deprioritized with configurable duration
- `AgentFactory`: creates `http.Agent`/`https.Agent` bound to specific `localAddress`
- Proxy support: SOCKS5 and HTTP CONNECT proxy configuration

### Config
- Added `egress` and `circuitBreaker` sections to the config schema

### Tests
- 20 new tests covering all circuit breaker states, transitions, metrics, IP pool strategies, per-provider assignment, rate limiting, and proxy selection
- All new tests passing