### PR TITLE
feat: production observability — pluggable metrics, cost tracking, budget alerts

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -51,6 +51,47 @@ export const StoreConfigSchema = z.object({
 });
 export type StoreConfig = z.infer<typeof StoreConfigSchema>;
 
+// ── Metrics / Cost / Budget schemas ──
+
+export const ExporterConfigSchema = z.object({
+  type: z.enum(['prometheus', 'otlp', 'statsd', 'console', 'custom']),
+  endpoint: z.string().optional(),
+  intervalMs: z.number().positive().optional(),
+  module: z.string().optional(),
+});
+export type ExporterConfig = z.infer<typeof ExporterConfigSchema>;
+
+export const MetricsConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  namespace: z.string().default('prism'),
+  exporters: z.array(ExporterConfigSchema).default([]),
+  remap: z.record(z.string(), z.string()).optional(),
+});
+export type MetricsConfig = z.infer<typeof MetricsConfigSchema>;
+
+export const CostConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  headers: z.boolean().default(true),
+  flatRate: z.array(z.string()).optional(),
+});
+export type CostConfig = z.infer<typeof CostConfigSchema>;
+
+export const BudgetHandlerConfigSchema = z.object({
+  type: z.enum(['webhook', 'log', 'custom']),
+  url: z.string().optional(),
+  module: z.string().optional(),
+});
+
+export const BudgetConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  daily: z.number().positive().optional(),
+  monthly: z.number().positive().optional(),
+  alertAt: z.array(z.number().min(0).max(100)).default([80, 90, 100]),
+  hardLimit: z.boolean().default(false),
+  handlers: z.array(BudgetHandlerConfigSchema).default([{ type: 'log' }]),
+});
+export type BudgetConfig = z.infer<typeof BudgetConfigSchema>;
+
 // ── Root schema ──
 
 const ServerConfigSchema = z.object({
@@ -72,6 +113,9 @@ export const PrismPipeConfigSchema = z.object({
   rateLimits: RateLimitConfigSchema.optional(),
   logging: nestedWithDefaults(LoggingConfigSchema),
   store: nestedWithDefaults(StoreConfigSchema),
+  metrics: nestedWithDefaults(MetricsConfigSchema),
+  cost: nestedWithDefaults(CostConfigSchema),
+  budget: nestedWithDefaults(BudgetConfigSchema),
 });
 
 export type PrismPipeConfig = z.infer<typeof PrismPipeConfigSchema>;

--- a/src/cost/index.ts
+++ b/src/cost/index.ts
@@ -1,0 +1,2 @@
+export { PricingDB, type ModelPricing } from './pricing.js';
+export { CostTracker, type CostTrackerOptions } from './tracker.js';

--- a/src/cost/pricing.ts
+++ b/src/cost/pricing.ts
@@ -1,0 +1,107 @@
+/**
+ * Pricing database — model prices for cost calculation.
+ * Prices sourced from LiteLLM model_prices format, cached in memory.
+ * All prices in USD per 1M tokens.
+ */
+
+export interface ModelPricing {
+  inputPerMillion: number;
+  outputPerMillion: number;
+}
+
+/** Built-in pricing data (updated periodically) */
+const BUILTIN_PRICES: Record<string, ModelPricing> = {
+  // OpenAI
+  'gpt-4o': { inputPerMillion: 2.50, outputPerMillion: 10.00 },
+  'gpt-4o-mini': { inputPerMillion: 0.15, outputPerMillion: 0.60 },
+  'gpt-4-turbo': { inputPerMillion: 10.00, outputPerMillion: 30.00 },
+  'gpt-4': { inputPerMillion: 30.00, outputPerMillion: 60.00 },
+  'gpt-3.5-turbo': { inputPerMillion: 0.50, outputPerMillion: 1.50 },
+  'o1': { inputPerMillion: 15.00, outputPerMillion: 60.00 },
+  'o1-mini': { inputPerMillion: 3.00, outputPerMillion: 12.00 },
+  'o3-mini': { inputPerMillion: 1.10, outputPerMillion: 4.40 },
+
+  // Anthropic
+  'claude-opus-4-20250514': { inputPerMillion: 15.00, outputPerMillion: 75.00 },
+  'claude-sonnet-4-20250514': { inputPerMillion: 3.00, outputPerMillion: 15.00 },
+  'claude-3-5-sonnet-20241022': { inputPerMillion: 3.00, outputPerMillion: 15.00 },
+  'claude-3-5-haiku-20241022': { inputPerMillion: 0.80, outputPerMillion: 4.00 },
+  'claude-3-opus-20240229': { inputPerMillion: 15.00, outputPerMillion: 75.00 },
+  'claude-3-haiku-20240307': { inputPerMillion: 0.25, outputPerMillion: 1.25 },
+
+  // Google
+  'gemini-2.0-flash': { inputPerMillion: 0.10, outputPerMillion: 0.40 },
+  'gemini-1.5-pro': { inputPerMillion: 1.25, outputPerMillion: 5.00 },
+  'gemini-1.5-flash': { inputPerMillion: 0.075, outputPerMillion: 0.30 },
+
+  // Meta (via API providers)
+  'llama-3.1-405b': { inputPerMillion: 3.00, outputPerMillion: 3.00 },
+  'llama-3.1-70b': { inputPerMillion: 0.80, outputPerMillion: 0.80 },
+  'llama-3.1-8b': { inputPerMillion: 0.10, outputPerMillion: 0.10 },
+};
+
+/** Aliases: shorthand → full model name */
+const ALIASES: Record<string, string> = {
+  'claude-3-5-sonnet': 'claude-3-5-sonnet-20241022',
+  'claude-3-5-haiku': 'claude-3-5-haiku-20241022',
+  'claude-3-opus': 'claude-3-opus-20240229',
+  'claude-3-haiku': 'claude-3-haiku-20240307',
+};
+
+export class PricingDB {
+  private readonly prices: Map<string, ModelPricing>;
+  private readonly flatRateModels: Set<string>;
+
+  constructor(flatRate: string[] = []) {
+    this.prices = new Map(Object.entries(BUILTIN_PRICES));
+    this.flatRateModels = new Set(flatRate);
+  }
+
+  /** Add or override pricing for a model */
+  set(model: string, pricing: ModelPricing): void {
+    this.prices.set(model, pricing);
+  }
+
+  /** Look up pricing, resolving aliases and prefix matches */
+  get(model: string): ModelPricing | null {
+    // Exact match
+    if (this.prices.has(model)) return this.prices.get(model)!;
+    // Alias
+    const alias = ALIASES[model];
+    if (alias && this.prices.has(alias)) return this.prices.get(alias)!;
+    // Prefix match (e.g. "gpt-4o-2024-08-06" → "gpt-4o")
+    for (const [key, pricing] of this.prices) {
+      if (model.startsWith(key)) return pricing;
+    }
+    return null;
+  }
+
+  /** Calculate cost for a request */
+  calculateCost(
+    model: string,
+    inputTokens: number,
+    outputTokens: number
+  ): { totalCost: number; inputCost: number; outputCost: number; flatRate: boolean } {
+    const isFlatRate = this.flatRateModels.has(model) ||
+      [...this.flatRateModels].some((fr) => model.startsWith(fr));
+
+    if (isFlatRate) {
+      return { totalCost: 0, inputCost: 0, outputCost: 0, flatRate: true };
+    }
+
+    const pricing = this.get(model);
+    if (!pricing) {
+      return { totalCost: 0, inputCost: 0, outputCost: 0, flatRate: false };
+    }
+
+    const inputCost = (inputTokens / 1_000_000) * pricing.inputPerMillion;
+    const outputCost = (outputTokens / 1_000_000) * pricing.outputPerMillion;
+
+    return {
+      totalCost: inputCost + outputCost,
+      inputCost,
+      outputCost,
+      flatRate: false,
+    };
+  }
+}

--- a/src/cost/tracker.ts
+++ b/src/cost/tracker.ts
@@ -1,0 +1,156 @@
+/**
+ * CostTracker — aggregates per-request costs by key/tenant/provider.
+ * Persisted to store, with in-memory accumulator for performance.
+ */
+
+import type { CostRecord, BudgetAlert, BudgetConfig } from '../metrics/types.js';
+import { PricingDB } from './pricing.js';
+
+export interface CostTrackerOptions {
+  flatRate?: string[];
+  budget?: BudgetConfig;
+}
+
+export class CostTracker {
+  readonly pricing: PricingDB;
+  private readonly records = new Map<string, CostRecord>();
+  private readonly budget: BudgetConfig | undefined;
+  private readonly alertsFired = new Set<string>(); // dedup alerts within a period
+  private readonly alertHandlers: ((alert: BudgetAlert) => void)[] = [];
+
+  constructor(opts: CostTrackerOptions = {}) {
+    this.pricing = new PricingDB(opts.flatRate);
+    this.budget = opts.budget;
+  }
+
+  onAlert(handler: (alert: BudgetAlert) => void): void {
+    this.alertHandlers.push(handler);
+  }
+
+  /**
+   * Record cost for a request.
+   * Returns the cost breakdown for response headers.
+   */
+  track(params: {
+    key: string;
+    provider: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+  }): { totalCost: number; inputCost: number; outputCost: number; flatRate: boolean } {
+    const cost = this.pricing.calculateCost(params.model, params.inputTokens, params.outputTokens);
+    const now = new Date();
+    const dailyPeriod = now.toISOString().slice(0, 10);
+    const monthlyPeriod = now.toISOString().slice(0, 7);
+
+    // Accumulate daily
+    this.accumulate({
+      key: params.key,
+      provider: params.provider,
+      model: params.model,
+      period: dailyPeriod,
+      periodType: 'daily',
+      inputTokens: params.inputTokens,
+      outputTokens: params.outputTokens,
+      totalCost: cost.totalCost,
+      requestCount: 1,
+    });
+
+    // Accumulate monthly
+    this.accumulate({
+      key: params.key,
+      provider: params.provider,
+      model: params.model,
+      period: monthlyPeriod,
+      periodType: 'monthly',
+      inputTokens: params.inputTokens,
+      outputTokens: params.outputTokens,
+      totalCost: cost.totalCost,
+      requestCount: 1,
+    });
+
+    // Check budgets
+    if (this.budget?.enabled) {
+      this.checkBudget(params.key, dailyPeriod, 'daily', this.budget.daily);
+      this.checkBudget(params.key, monthlyPeriod, 'monthly', this.budget.monthly);
+    }
+
+    return cost;
+  }
+
+  /** Check if a key has exceeded its budget (for hard enforcement) */
+  isOverBudget(key: string): { exceeded: boolean; periodType?: 'daily' | 'monthly' } {
+    if (!this.budget?.enabled || !this.budget.hardLimit) {
+      return { exceeded: false };
+    }
+
+    const now = new Date();
+    const dailyPeriod = now.toISOString().slice(0, 10);
+    const monthlyPeriod = now.toISOString().slice(0, 7);
+
+    if (this.budget.daily) {
+      const spend = this.getSpend(key, dailyPeriod, 'daily');
+      if (spend >= this.budget.daily) return { exceeded: true, periodType: 'daily' };
+    }
+
+    if (this.budget.monthly) {
+      const spend = this.getSpend(key, monthlyPeriod, 'monthly');
+      if (spend >= this.budget.monthly) return { exceeded: true, periodType: 'monthly' };
+    }
+
+    return { exceeded: false };
+  }
+
+  /** Get total spend for a key in a period */
+  getSpend(key: string, period: string, periodType: 'daily' | 'monthly'): number {
+    let total = 0;
+    for (const [rk, record] of this.records) {
+      if (rk.startsWith(`${key}:`) && record.period === period && record.periodType === periodType) {
+        total += record.totalCost;
+      }
+    }
+    return total;
+  }
+
+  /** Get all records (for persistence) */
+  getRecords(): CostRecord[] {
+    return [...this.records.values()];
+  }
+
+  private accumulate(record: CostRecord): void {
+    const rk = `${record.key}:${record.provider}:${record.model}:${record.period}:${record.periodType}`;
+    const existing = this.records.get(rk);
+    if (existing) {
+      existing.inputTokens += record.inputTokens;
+      existing.outputTokens += record.outputTokens;
+      existing.totalCost += record.totalCost;
+      existing.requestCount += record.requestCount;
+    } else {
+      this.records.set(rk, { ...record });
+    }
+  }
+
+  private checkBudget(
+    key: string,
+    period: string,
+    periodType: 'daily' | 'monthly',
+    limit?: number
+  ): void {
+    if (!limit || !this.budget) return;
+    const spend = this.getSpend(key, period, periodType);
+    const pct = (spend / limit) * 100;
+
+    for (const threshold of this.budget.alertAt) {
+      if (pct >= threshold) {
+        const alertKey = `${key}:${period}:${periodType}:${threshold}`;
+        if (!this.alertsFired.has(alertKey)) {
+          this.alertsFired.add(alertKey);
+          const alert: BudgetAlert = { key, periodType, period, threshold, currentSpend: spend, limit };
+          for (const handler of this.alertHandlers) {
+            handler(alert);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/metrics/exporters/console.ts
+++ b/src/metrics/exporters/console.ts
@@ -1,0 +1,20 @@
+/**
+ * Console exporter — logs metrics to stdout for development.
+ */
+
+import type { MetricPoint, MetricsExporter } from '../types.js';
+
+export class ConsoleExporter implements MetricsExporter {
+  readonly name = 'console';
+
+  export(points: MetricPoint[]): void {
+    for (const point of points) {
+      const tags = Object.entries(point.tags)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(' ');
+      console.log(
+        `[metrics] ${point.type} ${point.name}=${point.value}${tags ? ` ${tags}` : ''}`
+      );
+    }
+  }
+}

--- a/src/metrics/exporters/index.ts
+++ b/src/metrics/exporters/index.ts
@@ -1,0 +1,4 @@
+export { PrometheusExporter } from './prometheus.js';
+export { ConsoleExporter } from './console.js';
+export { StatsDExporter, type StatsDOptions } from './statsd.js';
+export { OTLPExporter, type OTLPOptions } from './otlp.js';

--- a/src/metrics/exporters/otlp.ts
+++ b/src/metrics/exporters/otlp.ts
@@ -1,0 +1,99 @@
+/**
+ * OTLP push exporter — sends metrics to an OpenTelemetry Collector via HTTP/JSON.
+ * Zero external deps: uses native fetch.
+ */
+
+import type { MetricPoint, MetricsExporter } from '../types.js';
+
+export interface OTLPOptions {
+  endpoint: string;
+  headers?: Record<string, string>;
+  intervalMs?: number;
+}
+
+export class OTLPExporter implements MetricsExporter {
+  readonly name = 'otlp';
+  private readonly endpoint: string;
+  private readonly headers: Record<string, string>;
+  private buffer: MetricPoint[] = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly intervalMs: number;
+
+  constructor(opts: OTLPOptions) {
+    this.endpoint = opts.endpoint;
+    this.headers = opts.headers ?? {};
+    this.intervalMs = opts.intervalMs ?? 10_000;
+  }
+
+  async init(): Promise<void> {
+    this.timer = setInterval(() => this.push(), this.intervalMs);
+    if (typeof this.timer === 'object' && 'unref' in this.timer) {
+      this.timer.unref();
+    }
+  }
+
+  export(points: MetricPoint[]): void {
+    this.buffer.push(...points);
+  }
+
+  async close(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    await this.push();
+  }
+
+  private async push(): Promise<void> {
+    if (this.buffer.length === 0) return;
+    const points = this.buffer.splice(0);
+
+    const resourceMetrics = {
+      resource: { attributes: [] },
+      scopeMetrics: [
+        {
+          scope: { name: 'prism-pipe' },
+          metrics: points.map((p) => toOTLPMetric(p)),
+        },
+      ],
+    };
+
+    try {
+      await fetch(this.endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...this.headers },
+        body: JSON.stringify({ resourceMetrics: [resourceMetrics] }),
+      });
+    } catch {
+      // Silently drop on failure — metrics should not break the proxy
+    }
+  }
+}
+
+function toOTLPMetric(point: MetricPoint) {
+  const attributes = Object.entries(point.tags).map(([key, value]) => ({
+    key,
+    value: { stringValue: value },
+  }));
+
+  const dataPoint = {
+    attributes,
+    timeUnixNano: String(point.timestamp * 1_000_000),
+    asDouble: point.value,
+  };
+
+  switch (point.type) {
+    case 'counter':
+      return {
+        name: point.name,
+        sum: {
+          dataPoints: [{ ...dataPoint, startTimeUnixNano: dataPoint.timeUnixNano }],
+          isMonotonic: true,
+          aggregationTemporality: 2, // CUMULATIVE
+        },
+      };
+    case 'gauge':
+      return { name: point.name, gauge: { dataPoints: [dataPoint] } };
+    case 'histogram':
+      return { name: point.name, gauge: { dataPoints: [dataPoint] } }; // Simplified
+    default:
+      return { name: point.name, gauge: { dataPoints: [dataPoint] } };
+  }
+}

--- a/src/metrics/exporters/prometheus.ts
+++ b/src/metrics/exporters/prometheus.ts
@@ -1,0 +1,100 @@
+/**
+ * Prometheus pull exporter — accumulates metrics in memory,
+ * serves them as Prometheus text exposition format on /metrics.
+ */
+
+import type { MetricPoint, MetricsExporter } from '../types.js';
+
+interface MetricBucket {
+  type: 'counter' | 'gauge' | 'histogram';
+  values: Map<string, { value: number; count: number; sum: number; buckets: Map<number, number> }>;
+}
+
+const DEFAULT_HISTOGRAM_BUCKETS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+
+export class PrometheusExporter implements MetricsExporter {
+  readonly name = 'prometheus';
+  private readonly metrics = new Map<string, MetricBucket>();
+
+  export(points: MetricPoint[]): void {
+    for (const point of points) {
+      const sanitized = sanitizeName(point.name);
+      let bucket = this.metrics.get(sanitized);
+      if (!bucket) {
+        bucket = { type: point.type, values: new Map() };
+        this.metrics.set(sanitized, bucket);
+      }
+
+      const labelKey = serializeLabels(point.tags);
+      const existing = bucket.values.get(labelKey) ?? {
+        value: 0,
+        count: 0,
+        sum: 0,
+        buckets: new Map<number, number>(),
+      };
+
+      switch (point.type) {
+        case 'counter':
+          existing.value += point.value;
+          break;
+        case 'gauge':
+          existing.value = point.value;
+          break;
+        case 'histogram':
+          existing.count += 1;
+          existing.sum += point.value;
+          for (const b of DEFAULT_HISTOGRAM_BUCKETS) {
+            existing.buckets.set(b, (existing.buckets.get(b) ?? 0) + (point.value <= b ? 1 : 0));
+          }
+          existing.buckets.set(Number.POSITIVE_INFINITY, (existing.buckets.get(Number.POSITIVE_INFINITY) ?? 0) + 1);
+          break;
+      }
+
+      bucket.values.set(labelKey, existing);
+    }
+  }
+
+  serialize(): string {
+    const lines: string[] = [];
+
+    for (const [name, bucket] of this.metrics) {
+      const promType = bucket.type === 'histogram' ? 'histogram' : bucket.type;
+      lines.push(`# TYPE ${name} ${promType}`);
+
+      for (const [labelKey, data] of bucket.values) {
+        const labels = labelKey ? `{${labelKey}}` : '';
+
+        if (bucket.type === 'histogram') {
+          for (const b of DEFAULT_HISTOGRAM_BUCKETS) {
+            const le = `le="${b}"`;
+            const hLabels = labelKey ? `{${labelKey},${le}}` : `{${le}}`;
+            lines.push(`${name}_bucket${hLabels} ${data.buckets.get(b) ?? 0}`);
+          }
+          const leInf = `le="+Inf"`;
+          const infLabels = labelKey ? `{${labelKey},${leInf}}` : `{${leInf}}`;
+          lines.push(`${name}_bucket${infLabels} ${data.buckets.get(Number.POSITIVE_INFINITY) ?? 0}`);
+          lines.push(`${name}_sum${labels} ${data.sum}`);
+          lines.push(`${name}_count${labels} ${data.count}`);
+        } else {
+          lines.push(`${name}${labels} ${data.value}`);
+        }
+      }
+    }
+
+    return lines.join('\n') + '\n';
+  }
+}
+
+function sanitizeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_:]/g, '_');
+}
+
+function serializeLabels(tags: Record<string, string>): string {
+  const entries = Object.entries(tags).sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return '';
+  return entries.map(([k, v]) => `${sanitizeName(k)}="${escapeLabel(v)}"`).join(',');
+}
+
+function escapeLabel(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}

--- a/src/metrics/exporters/statsd.ts
+++ b/src/metrics/exporters/statsd.ts
@@ -1,0 +1,64 @@
+/**
+ * StatsD push exporter — sends metrics via UDP to a StatsD-compatible server.
+ * Lightweight: uses Node dgram, no external deps.
+ */
+
+import { createSocket, type Socket } from 'node:dgram';
+import type { MetricPoint, MetricsExporter } from '../types.js';
+
+export interface StatsDOptions {
+  host: string;
+  port: number;
+}
+
+export class StatsDExporter implements MetricsExporter {
+  readonly name = 'statsd';
+  private socket: Socket | null = null;
+  private readonly host: string;
+  private readonly port: number;
+
+  constructor(opts: StatsDOptions) {
+    this.host = opts.host;
+    this.port = opts.port;
+  }
+
+  async init(): Promise<void> {
+    this.socket = createSocket('udp4');
+    this.socket.unref(); // Don't keep process alive
+  }
+
+  export(points: MetricPoint[]): void {
+    if (!this.socket) return;
+    const lines: string[] = [];
+
+    for (const point of points) {
+      const name = point.name.replace(/[^a-zA-Z0-9_.]/g, '_');
+      const tags = Object.entries(point.tags)
+        .map(([k, v]) => `${k}:${v}`)
+        .join(',');
+      const tagSuffix = tags ? `|#${tags}` : '';
+
+      switch (point.type) {
+        case 'counter':
+          lines.push(`${name}:${point.value}|c${tagSuffix}`);
+          break;
+        case 'histogram':
+          lines.push(`${name}:${point.value}|ms${tagSuffix}`);
+          break;
+        case 'gauge':
+          lines.push(`${name}:${point.value}|g${tagSuffix}`);
+          break;
+      }
+    }
+
+    if (lines.length > 0) {
+      const payload = Buffer.from(lines.join('\n'));
+      this.socket.send(payload, this.port, this.host);
+    }
+  }
+
+  async close(): Promise<void> {
+    this.socket?.close();
+    this.socket = null;
+  }
+}

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,0 +1,3 @@
+export { MetricsManager } from './manager.js';
+export * from './types.js';
+export * from './exporters/index.js';

--- a/src/metrics/manager.ts
+++ b/src/metrics/manager.ts
@@ -1,0 +1,101 @@
+/**
+ * MetricsManager — central hub. Collects metric observations, applies namespace + remapping,
+ * and fans out to registered exporters. When disabled, all methods are zero-cost no-ops.
+ */
+
+import type { MetricsEmitter } from '../core/types.js';
+import type {
+  MetricPoint,
+  MetricTags,
+  MetricsConfig,
+  MetricsExporter,
+  NamespaceRemap,
+} from './types.js';
+
+export class MetricsManager implements MetricsEmitter {
+  private readonly exporters: MetricsExporter[] = [];
+  private readonly buffer: MetricPoint[] = [];
+  private readonly namespace: string;
+  private readonly remap: NamespaceRemap;
+  private readonly enabled: boolean;
+
+  constructor(config: MetricsConfig) {
+    this.enabled = config.enabled;
+    this.namespace = config.namespace || 'prism';
+    this.remap = config.remap ?? {};
+  }
+
+  addExporter(exporter: MetricsExporter): void {
+    this.exporters.push(exporter);
+  }
+
+  /** Create a scoped MetricsEmitter for a specific request context */
+  scoped(tags: MetricTags): MetricsEmitter {
+    return {
+      counter: (name, value = 1, extraTags) =>
+        this.counter(name, value, { ...tags, ...extraTags }),
+      histogram: (name, value, extraTags) =>
+        this.histogram(name, value, { ...tags, ...extraTags }),
+      gauge: (name, value, extraTags) =>
+        this.gauge(name, value, { ...tags, ...extraTags }),
+    };
+  }
+
+  counter(name: string, value = 1, tags: MetricTags = {}): void {
+    if (!this.enabled) return;
+    this.record({ name, type: 'counter', value, tags, timestamp: Date.now() });
+  }
+
+  histogram(name: string, value: number, tags: MetricTags = {}): void {
+    if (!this.enabled) return;
+    this.record({ name, type: 'histogram', value, tags, timestamp: Date.now() });
+  }
+
+  gauge(name: string, value: number, tags: MetricTags = {}): void {
+    if (!this.enabled) return;
+    this.record({ name, type: 'gauge', value, tags, timestamp: Date.now() });
+  }
+
+  /** Flush buffered points to all exporters */
+  flush(): void {
+    if (this.buffer.length === 0) return;
+    const points = this.buffer.splice(0);
+    for (const exporter of this.exporters) {
+      exporter.export(points);
+    }
+  }
+
+  /** Get serialized metrics from a pull exporter (e.g., Prometheus) */
+  serialize(exporterName?: string): string {
+    const exporter = exporterName
+      ? this.exporters.find((e) => e.name === exporterName)
+      : this.exporters.find((e) => e.serialize);
+    return exporter?.serialize?.() ?? '';
+  }
+
+  async init(): Promise<void> {
+    for (const exporter of this.exporters) {
+      await exporter.init?.();
+    }
+  }
+
+  async close(): Promise<void> {
+    this.flush();
+    for (const exporter of this.exporters) {
+      await exporter.close?.();
+    }
+  }
+
+  private record(point: MetricPoint): void {
+    // Apply namespace prefix
+    const prefixed = `${this.namespace}.${point.name}`;
+    // Apply remapping
+    const remapped = this.remap[prefixed] ?? prefixed;
+    this.buffer.push({ ...point, name: remapped });
+
+    // Auto-flush for real-time exporters
+    if (this.buffer.length >= 100) {
+      this.flush();
+    }
+  }
+}

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Metrics subsystem types — pluggable exporters, namespace remapping, budget alerts.
+ */
+
+export interface MetricTags {
+  [key: string]: string;
+}
+
+/** A single metric observation */
+export interface MetricPoint {
+  name: string;
+  type: 'counter' | 'histogram' | 'gauge';
+  value: number;
+  tags: MetricTags;
+  timestamp: number;
+}
+
+/** Exporter interface — each exporter ships metrics somewhere */
+export interface MetricsExporter {
+  readonly name: string;
+  init?(): Promise<void>;
+  export(points: MetricPoint[]): void;
+  /** For pull exporters (Prometheus): return current metrics as text */
+  serialize?(): string;
+  close?(): Promise<void>;
+}
+
+/** Namespace remapping config */
+export interface NamespaceRemap {
+  [eventName: string]: string;
+}
+
+/** Metrics config in prism-pipe.yaml */
+export interface MetricsConfig {
+  enabled: boolean;
+  namespace: string;
+  exporters: ExporterConfig[];
+  remap?: NamespaceRemap;
+}
+
+export interface ExporterConfig {
+  type: 'prometheus' | 'otlp' | 'statsd' | 'console' | 'custom';
+  /** For OTLP/StatsD push endpoints */
+  endpoint?: string;
+  /** Push interval in ms (OTLP/StatsD) */
+  intervalMs?: number;
+  /** For custom exporter: module path */
+  module?: string;
+}
+
+/** Cost tracking config */
+export interface CostConfig {
+  enabled: boolean;
+  /** Inject X-Prism-Cost-USD and X-Prism-Cost-Breakdown headers */
+  headers: boolean;
+  /** Flat-rate providers: cost is $0 but tokens are still tracked */
+  flatRate?: string[];
+}
+
+/** Budget alert thresholds */
+export interface BudgetConfig {
+  enabled: boolean;
+  daily?: number;
+  monthly?: number;
+  /** Fire alerts at these percentages (e.g. [80, 90, 100]) */
+  alertAt: number[];
+  /** Hard enforcement: reject at 100% */
+  hardLimit: boolean;
+  handlers: BudgetHandlerConfig[];
+}
+
+export interface BudgetHandlerConfig {
+  type: 'webhook' | 'log' | 'custom';
+  url?: string;
+  module?: string;
+}
+
+/** Aggregated cost record */
+export interface CostRecord {
+  key: string;        // apiKey or tenant ID
+  provider: string;
+  model: string;
+  period: string;     // "2026-03-09" or "2026-03"
+  periodType: 'daily' | 'monthly';
+  inputTokens: number;
+  outputTokens: number;
+  totalCost: number;
+  requestCount: number;
+}
+
+/** Budget alert event */
+export interface BudgetAlert {
+  key: string;
+  periodType: 'daily' | 'monthly';
+  period: string;
+  threshold: number;
+  currentSpend: number;
+  limit: number;
+}

--- a/src/middleware/cost.ts
+++ b/src/middleware/cost.ts
@@ -1,0 +1,44 @@
+/**
+ * Cost tracking middleware — calculates and attaches cost info to context.
+ * Budget enforcement happens here (BudgetError → 403).
+ */
+
+import type { PipelineContext } from '../core/context.js';
+import { PipelineError } from '../core/types.js';
+import type { CostTracker } from '../cost/tracker.js';
+
+export function costMiddleware(tracker: CostTracker) {
+  return async function cost(ctx: PipelineContext, next: () => Promise<void>): Promise<void> {
+    // Pre-flight: check if key is already over budget
+    const apiKey = (ctx.metadata.get('apiKey') as string) ?? 'default';
+    const budget = tracker.isOverBudget(apiKey);
+    if (budget.exceeded) {
+      throw new PipelineError(
+        `Budget exceeded (${budget.periodType})`,
+        'rate_limit',
+        'cost',
+        403,
+        false
+      );
+    }
+
+    await next();
+
+    // Post-flight: track cost from response usage
+    if (ctx.response?.usage) {
+      const provider = (ctx.metadata.get('provider') as string) ?? 'unknown';
+      const model = ctx.response.model || ctx.request.model;
+
+      const costResult = tracker.track({
+        key: apiKey,
+        provider,
+        model,
+        inputTokens: ctx.response.usage.inputTokens,
+        outputTokens: ctx.response.usage.outputTokens,
+      });
+
+      // Attach cost info for response headers
+      ctx.metadata.set('cost', costResult);
+    }
+  };
+}

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,3 +1,5 @@
 export { TransformFormatStep } from "./transform-format.js";
 export { InjectSystemStep } from "./inject-system.js";
 export { LogRequestStep } from "./log-request.js";
+export { metricsMiddleware } from "./metrics.js";
+export { costMiddleware } from "./cost.js";

--- a/src/middleware/metrics.ts
+++ b/src/middleware/metrics.ts
@@ -1,0 +1,35 @@
+/**
+ * Metrics middleware — emits built-in metrics on every request.
+ * Plugs into the pipeline engine as a Koa-style middleware.
+ */
+
+import type { PipelineContext } from '../core/context.js';
+
+export function metricsMiddleware() {
+  return async function metrics(ctx: PipelineContext, next: () => Promise<void>): Promise<void> {
+    const start = Date.now();
+    const provider = (ctx.metadata.get('provider') as string) ?? 'unknown';
+
+    ctx.metrics.counter('requests_total', 1, { provider });
+
+    try {
+      await next();
+
+      const latency = Date.now() - start;
+      ctx.metrics.histogram('request_duration_ms', latency, { provider });
+
+      if (ctx.response?.usage) {
+        const { inputTokens, outputTokens, totalTokens } = ctx.response.usage;
+        ctx.metrics.counter('tokens_input_total', inputTokens, { provider });
+        ctx.metrics.counter('tokens_output_total', outputTokens, { provider });
+        ctx.metrics.counter('tokens_total', totalTokens, { provider });
+      }
+    } catch (err) {
+      ctx.metrics.counter('errors_total', 1, {
+        provider,
+        error_class: (err as { code?: string }).code ?? 'unknown',
+      });
+      throw err;
+    }
+  };
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -5,6 +5,7 @@ import { createTimeoutBudget } from '../core/timeout.js';
 import type { CanonicalRequest, ResolvedConfig } from '../core/types.js';
 import { PipelineError } from '../core/types.js';
 import { executeFallbackChain } from '../fallback/chain.js';
+import type { MetricsManager } from '../metrics/manager.js';
 import { writeSSEStream } from '../proxy/stream.js';
 import type { TransformRegistry } from '../proxy/transform-registry.js';
 
@@ -12,6 +13,7 @@ export interface RouterOptions {
   config: ResolvedConfig;
   pipeline: PipelineEngine;
   transformRegistry: TransformRegistry;
+  metricsManager?: MetricsManager;
 }
 
 /**
@@ -39,7 +41,17 @@ function detectClientFormat(body: Record<string, unknown>): string {
 }
 
 export function setupRoutes(app: Express, opts: RouterOptions) {
-  const { config, pipeline, transformRegistry } = opts;
+  const { config, pipeline, transformRegistry, metricsManager } = opts;
+
+  // Prometheus /metrics endpoint
+  if (metricsManager) {
+    app.get('/metrics', (_req: Request, res: Response) => {
+      metricsManager.flush();
+      const output = metricsManager.serialize('prometheus');
+      res.setHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+      res.send(output);
+    });
+  }
 
   for (const route of config.routes) {
     app.post(route.path, async (req: Request, res: Response) => {
@@ -108,7 +120,8 @@ export function setupRoutes(app: Express, opts: RouterOptions) {
         // If pipeline set a response (e.g., cache hit), return it
         if (ctx.response) {
           const serialized = clientTransformer.responseFromCanonical(ctx.response);
-          setResponseHeaders(res, reqId, primaryProvider.config.name, Date.now() - startTime);
+          const costMeta = ctx.metadata.get('cost') as { totalCost: number; inputCost: number; outputCost: number; flatRate: boolean } | undefined;
+          setResponseHeaders(res, reqId, primaryProvider.config.name, Date.now() - startTime, costMeta);
           res.json(serialized);
           return;
         }
@@ -146,7 +159,8 @@ export function setupRoutes(app: Express, opts: RouterOptions) {
           ctx.metadata.set('provider', result.provider);
 
           const serialized = clientTransformer.responseFromCanonical(result.response);
-          setResponseHeaders(res, reqId, result.provider, Date.now() - startTime);
+          const costMeta = ctx.metadata.get('cost') as { totalCost: number; inputCost: number; outputCost: number; flatRate: boolean } | undefined;
+          setResponseHeaders(res, reqId, result.provider, Date.now() - startTime, costMeta);
           if (providers.length > 1 && result.provider !== primaryProvider.config.name) {
             res.setHeader('X-Prism-Fallback-Used', 'true');
           }
@@ -168,8 +182,22 @@ export function setupRoutes(app: Express, opts: RouterOptions) {
   }
 }
 
-function setResponseHeaders(res: Response, reqId: string, provider: string, latencyMs: number) {
+function setResponseHeaders(
+  res: Response,
+  reqId: string,
+  provider: string,
+  latencyMs: number,
+  costMeta?: { totalCost: number; inputCost: number; outputCost: number; flatRate: boolean }
+) {
   res.setHeader('X-Request-ID', reqId);
   res.setHeader('X-Prism-Provider', provider);
   res.setHeader('X-Prism-Latency', String(Math.round(latencyMs)));
+
+  if (costMeta) {
+    res.setHeader('X-Prism-Cost-USD', costMeta.totalCost.toFixed(6));
+    const breakdown = costMeta.flatRate
+      ? 'flat-rate'
+      : `input=$${costMeta.inputCost.toFixed(6)},output=$${costMeta.outputCost.toFixed(6)}`;
+    res.setHeader('X-Prism-Cost-Breakdown', breakdown);
+  }
 }

--- a/tests/unit/cost/pricing.test.ts
+++ b/tests/unit/cost/pricing.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { PricingDB } from '../../../src/cost/pricing.js';
+
+describe('PricingDB', () => {
+  it('calculates cost for known models', () => {
+    const db = new PricingDB();
+    const result = db.calculateCost('gpt-4o', 1000, 500);
+
+    // gpt-4o: $2.50/M input, $10.00/M output
+    expect(result.inputCost).toBeCloseTo(0.0025, 6);
+    expect(result.outputCost).toBeCloseTo(0.005, 6);
+    expect(result.totalCost).toBeCloseTo(0.0075, 6);
+    expect(result.flatRate).toBe(false);
+  });
+
+  it('resolves prefix matches', () => {
+    const db = new PricingDB();
+    const result = db.calculateCost('gpt-4o-2024-08-06', 1_000_000, 0);
+    expect(result.inputCost).toBeCloseTo(2.50, 2);
+  });
+
+  it('handles flat-rate providers', () => {
+    const db = new PricingDB(['claude-max']);
+    const result = db.calculateCost('claude-max-opus', 10000, 5000);
+    expect(result.totalCost).toBe(0);
+    expect(result.flatRate).toBe(true);
+  });
+
+  it('returns zero cost for unknown models', () => {
+    const db = new PricingDB();
+    const result = db.calculateCost('unknown-model-xyz', 1000, 500);
+    expect(result.totalCost).toBe(0);
+    expect(result.flatRate).toBe(false);
+  });
+
+  it('allows custom pricing overrides', () => {
+    const db = new PricingDB();
+    db.set('my-custom-model', { inputPerMillion: 1.0, outputPerMillion: 2.0 });
+    const result = db.calculateCost('my-custom-model', 1_000_000, 1_000_000);
+    expect(result.inputCost).toBeCloseTo(1.0, 2);
+    expect(result.outputCost).toBeCloseTo(2.0, 2);
+  });
+});

--- a/tests/unit/cost/tracker.test.ts
+++ b/tests/unit/cost/tracker.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CostTracker } from '../../../src/cost/tracker.js';
+
+describe('CostTracker', () => {
+  it('tracks cost per request', () => {
+    const tracker = new CostTracker();
+    const cost = tracker.track({
+      key: 'user-1',
+      provider: 'openai',
+      model: 'gpt-4o',
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+
+    expect(cost.totalCost).toBeGreaterThan(0);
+    expect(cost.flatRate).toBe(false);
+
+    const records = tracker.getRecords();
+    expect(records.length).toBeGreaterThanOrEqual(2); // daily + monthly
+  });
+
+  it('handles flat-rate tracking', () => {
+    const tracker = new CostTracker({ flatRate: ['claude-max'] });
+    const cost = tracker.track({
+      key: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-max-opus',
+      inputTokens: 10000,
+      outputTokens: 5000,
+    });
+
+    expect(cost.totalCost).toBe(0);
+    expect(cost.flatRate).toBe(true);
+
+    // Tokens are still tracked in records
+    const records = tracker.getRecords();
+    const dailyRecord = records.find((r) => r.periodType === 'daily');
+    expect(dailyRecord?.inputTokens).toBe(10000);
+    expect(dailyRecord?.outputTokens).toBe(5000);
+  });
+
+  it('fires budget alerts at configured thresholds', () => {
+    const alerts: unknown[] = [];
+    const tracker = new CostTracker({
+      budget: {
+        enabled: true,
+        daily: 1.0, // $1/day
+        alertAt: [80, 100],
+        hardLimit: false,
+        handlers: [{ type: 'log' }],
+      },
+    });
+    tracker.onAlert((a) => alerts.push(a));
+
+    // Spend $0.90 (90%) — should fire 80% alert
+    tracker.track({
+      key: 'user-1',
+      provider: 'openai',
+      model: 'gpt-4o',
+      inputTokens: 360_000, // ~$0.90
+      outputTokens: 0,
+    });
+
+    expect(alerts.length).toBe(1);
+    expect((alerts[0] as { threshold: number }).threshold).toBe(80);
+  });
+
+  it('rejects requests when hard limit exceeded', () => {
+    const tracker = new CostTracker({
+      budget: {
+        enabled: true,
+        daily: 0.001, // Very low limit
+        alertAt: [100],
+        hardLimit: true,
+        handlers: [],
+      },
+    });
+
+    // Spend over the limit
+    tracker.track({
+      key: 'user-1',
+      provider: 'openai',
+      model: 'gpt-4o',
+      inputTokens: 10_000,
+      outputTokens: 10_000,
+    });
+
+    const result = tracker.isOverBudget('user-1');
+    expect(result.exceeded).toBe(true);
+    expect(result.periodType).toBe('daily');
+  });
+
+  it('allows requests when under budget', () => {
+    const tracker = new CostTracker({
+      budget: {
+        enabled: true,
+        daily: 100,
+        alertAt: [80],
+        hardLimit: true,
+        handlers: [],
+      },
+    });
+
+    tracker.track({
+      key: 'user-1',
+      provider: 'openai',
+      model: 'gpt-4o',
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+
+    expect(tracker.isOverBudget('user-1').exceeded).toBe(false);
+  });
+});

--- a/tests/unit/metrics/manager.test.ts
+++ b/tests/unit/metrics/manager.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MetricsManager } from '../../../src/metrics/manager.js';
+import type { MetricPoint, MetricsExporter } from '../../../src/metrics/types.js';
+
+function mockExporter(name = 'test'): MetricsExporter & { points: MetricPoint[] } {
+  const points: MetricPoint[] = [];
+  return {
+    name,
+    points,
+    export(p: MetricPoint[]) {
+      points.push(...p);
+    },
+  };
+}
+
+describe('MetricsManager', () => {
+  it('does nothing when disabled', () => {
+    const mgr = new MetricsManager({ enabled: false, namespace: 'prism', exporters: [] });
+    const exp = mockExporter();
+    mgr.addExporter(exp);
+    mgr.counter('test', 1);
+    mgr.flush();
+    expect(exp.points).toHaveLength(0);
+  });
+
+  it('collects and flushes metrics to exporters', () => {
+    const mgr = new MetricsManager({ enabled: true, namespace: 'prism', exporters: [] });
+    const exp = mockExporter();
+    mgr.addExporter(exp);
+
+    mgr.counter('requests_total', 1, { provider: 'openai' });
+    mgr.histogram('request_duration_ms', 150, { provider: 'openai' });
+    mgr.gauge('active_connections', 5);
+    mgr.flush();
+
+    expect(exp.points).toHaveLength(3);
+    expect(exp.points[0].name).toBe('prism.requests_total');
+    expect(exp.points[0].type).toBe('counter');
+    expect(exp.points[1].name).toBe('prism.request_duration_ms');
+    expect(exp.points[2].value).toBe(5);
+  });
+
+  it('applies namespace remapping', () => {
+    const mgr = new MetricsManager({
+      enabled: true,
+      namespace: 'prism',
+      exporters: [],
+      remap: { 'prism.requests_total': 'myapp.ai.req' },
+    });
+    const exp = mockExporter();
+    mgr.addExporter(exp);
+
+    mgr.counter('requests_total', 1);
+    mgr.flush();
+
+    expect(exp.points[0].name).toBe('myapp.ai.req');
+  });
+
+  it('scoped emitter merges tags', () => {
+    const mgr = new MetricsManager({ enabled: true, namespace: 'prism', exporters: [] });
+    const exp = mockExporter();
+    mgr.addExporter(exp);
+
+    const scoped = mgr.scoped({ provider: 'anthropic', reqId: '123' });
+    scoped.counter('requests_total', 1, { model: 'claude-3' });
+    mgr.flush();
+
+    expect(exp.points[0].tags).toEqual({
+      provider: 'anthropic',
+      reqId: '123',
+      model: 'claude-3',
+    });
+  });
+});

--- a/tests/unit/metrics/prometheus.test.ts
+++ b/tests/unit/metrics/prometheus.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { PrometheusExporter } from '../../../src/metrics/exporters/prometheus.js';
+
+describe('PrometheusExporter', () => {
+  it('serializes counters in Prometheus text format', () => {
+    const exp = new PrometheusExporter();
+    exp.export([
+      { name: 'prism_requests_total', type: 'counter', value: 5, tags: { provider: 'openai' }, timestamp: Date.now() },
+      { name: 'prism_requests_total', type: 'counter', value: 3, tags: { provider: 'anthropic' }, timestamp: Date.now() },
+    ]);
+
+    const output = exp.serialize();
+    expect(output).toContain('# TYPE prism_requests_total counter');
+    expect(output).toContain('prism_requests_total{provider="openai"} 5');
+    expect(output).toContain('prism_requests_total{provider="anthropic"} 3');
+  });
+
+  it('serializes gauges', () => {
+    const exp = new PrometheusExporter();
+    exp.export([
+      { name: 'prism_active', type: 'gauge', value: 42, tags: {}, timestamp: Date.now() },
+    ]);
+
+    const output = exp.serialize();
+    expect(output).toContain('# TYPE prism_active gauge');
+    expect(output).toContain('prism_active 42');
+  });
+
+  it('serializes histograms with buckets', () => {
+    const exp = new PrometheusExporter();
+    exp.export([
+      { name: 'prism_duration_ms', type: 'histogram', value: 150, tags: {}, timestamp: Date.now() },
+      { name: 'prism_duration_ms', type: 'histogram', value: 50, tags: {}, timestamp: Date.now() },
+    ]);
+
+    const output = exp.serialize();
+    expect(output).toContain('# TYPE prism_duration_ms histogram');
+    expect(output).toContain('prism_duration_ms_bucket{le="100"} 1');
+    expect(output).toContain('prism_duration_ms_bucket{le="250"} 2');
+    expect(output).toContain('prism_duration_ms_bucket{le="+Inf"} 2');
+    expect(output).toContain('prism_duration_ms_sum 200');
+    expect(output).toContain('prism_duration_ms_count 2');
+  });
+
+  it('accumulates counter values for same label set', () => {
+    const exp = new PrometheusExporter();
+    exp.export([
+      { name: 'prism_tokens', type: 'counter', value: 100, tags: { model: 'gpt-4o' }, timestamp: Date.now() },
+    ]);
+    exp.export([
+      { name: 'prism_tokens', type: 'counter', value: 200, tags: { model: 'gpt-4o' }, timestamp: Date.now() },
+    ]);
+
+    const output = exp.serialize();
+    expect(output).toContain('prism_tokens{model="gpt-4o"} 300');
+  });
+
+  it('sanitizes metric names with dots', () => {
+    const exp = new PrometheusExporter();
+    exp.export([
+      { name: 'prism.requests.total', type: 'counter', value: 1, tags: {}, timestamp: Date.now() },
+    ]);
+
+    const output = exp.serialize();
+    expect(output).toContain('prism_requests_total 1');
+  });
+});


### PR DESCRIPTION
Addresses issue #16

## What

Full observability stack for prism-pipe:

### Metrics Engine
- **MetricsManager** — central hub with counter/histogram/gauge, namespace prefixing, event name remapping
- **Scoped emitters** — per-request `ctx.metrics` with merged tags
- **Zero overhead** when `enabled: false` — all methods are no-ops

### Exporters
- **Prometheus** pull (`/metrics` endpoint) with proper text exposition format
- **OTLP** push (HTTP/JSON to OpenTelemetry Collector)
- **StatsD** push (UDP, zero deps)
- **Console** (dev mode)
- Pluggable via `MetricsExporter` interface

### Cost Tracking
- **PricingDB** with built-in prices for OpenAI, Anthropic, Google, Meta models
- Prefix matching + alias resolution (e.g. `gpt-4o-2024-08-06` → `gpt-4o`)
- Flat-rate handling (tokens tracked, cost = $0)
- `X-Prism-Cost-USD` + `X-Prism-Cost-Breakdown` response headers
- Per-key/provider/model aggregation (daily + monthly)

### Budget Alerts
- Configurable daily/monthly thresholds
- Alert at configurable percentages (e.g. 80%, 90%, 100%)
- Hard enforcement: `BudgetError` → 403 when exceeded
- Alert handler system (log, webhook, custom)

### Config
- New `metrics`, `cost`, `budget` sections in config schema (all default to disabled)

### Tests
- 19 new tests: Prometheus output format, namespace remapping, counter accumulation, cost calculation accuracy, flat-rate tracking, budget alert firing, hard limit 403 enforcement