### PR TITLE
fix: preserve response_format and other passthrough fields during canonical transform

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -86,6 +86,13 @@ export interface CanonicalRequest {
   stopSequences?: string[];
   stream?: boolean;
   providerExtensions?: Record<string, unknown>;
+  /**
+   * Passthrough fields not explicitly modeled in the canonical schema.
+   * Captured from the incoming request and spread back into the outgoing request,
+   * ensuring fields like `response_format`, `logprobs`, `seed`, etc. survive
+   * the canonical round-trip without requiring explicit support for each one.
+   */
+  extras?: Record<string, unknown>;
 }
 
 export interface UsageInfo {

--- a/src/proxy/transforms/anthropic.ts
+++ b/src/proxy/transforms/anthropic.ts
@@ -91,6 +91,18 @@ export class AnthropicTransformer implements ProviderTransformer {
         inputSchema: (t.input_schema as Record<string, unknown>) ?? {},
       }));
     }
+
+    // Capture unrecognized fields into extras for passthrough
+    const knownKeys = new Set([
+      'model', 'messages', 'system', 'temperature', 'max_tokens', 'top_p',
+      'stop_sequences', 'stream', 'tools', 'tool_choice', 'metadata',
+    ]);
+    const extras: Record<string, unknown> = {};
+    for (const key of Object.keys(r)) {
+      if (!knownKeys.has(key)) extras[key] = r[key];
+    }
+    if (Object.keys(extras).length > 0) req.extras = extras;
+
     return req;
   }
 
@@ -164,6 +176,14 @@ export class AnthropicTransformer implements ProviderTransformer {
         input_schema: t.inputSchema,
       }));
     }
+
+    // Spread extras back into the outgoing request
+    if (req.extras) {
+      for (const [key, value] of Object.entries(req.extras)) {
+        if (!(key in result)) result[key] = value;
+      }
+    }
+
     return result;
   }
 

--- a/src/proxy/transforms/gemini.ts
+++ b/src/proxy/transforms/gemini.ts
@@ -115,6 +115,17 @@ export class GeminiTransformer implements ProviderTransformer {
       });
     }
 
+    // Capture unrecognized fields into extras for passthrough
+    const knownKeys = new Set([
+      'model', 'contents', 'systemInstruction', 'generationConfig', 'tools',
+      'toolConfig', 'safetySettings',
+    ]);
+    const extras: Record<string, unknown> = {};
+    for (const key of Object.keys(r)) {
+      if (!knownKeys.has(key)) extras[key] = r[key];
+    }
+    if (Object.keys(extras).length > 0) req.extras = extras;
+
     return req;
   }
 
@@ -196,6 +207,13 @@ export class GeminiTransformer implements ProviderTransformer {
           })),
         },
       ];
+    }
+
+    // Spread extras back into the outgoing request
+    if (req.extras) {
+      for (const [key, value] of Object.entries(req.extras)) {
+        if (!(key in result)) result[key] = value;
+      }
     }
 
     return result;

--- a/src/proxy/transforms/ollama.ts
+++ b/src/proxy/transforms/ollama.ts
@@ -123,6 +123,17 @@ export class OllamaTransformer implements ProviderTransformer {
         };
       });
     }
+
+    // Capture unrecognized fields into extras for passthrough
+    const knownKeys = new Set([
+      'model', 'messages', 'options', 'stream', 'tools', 'format',
+    ]);
+    const extras: Record<string, unknown> = {};
+    for (const key of Object.keys(r)) {
+      if (!knownKeys.has(key)) extras[key] = r[key];
+    }
+    if (Object.keys(extras).length > 0) req.extras = extras;
+
     return req;
   }
 
@@ -204,6 +215,14 @@ export class OllamaTransformer implements ProviderTransformer {
         function: { name: t.name, description: t.description, parameters: t.inputSchema },
       }));
     }
+
+    // Spread extras back into the outgoing request
+    if (req.extras) {
+      for (const [key, value] of Object.entries(req.extras)) {
+        if (!(key in result)) result[key] = value;
+      }
+    }
+
     return result;
   }
 

--- a/src/proxy/transforms/openai.ts
+++ b/src/proxy/transforms/openai.ts
@@ -118,6 +118,21 @@ export class OpenAITransformer implements ProviderTransformer {
         };
       });
     }
+
+    // Capture all fields not explicitly handled into extras for passthrough.
+    // This preserves response_format, logprobs, seed, frequency_penalty, etc.
+    const knownKeys = new Set([
+      'model', 'messages', 'temperature', 'max_tokens', 'max_completion_tokens',
+      'top_p', 'stop', 'stream', 'tools', 'tool_choice',
+    ]);
+    const extras: Record<string, unknown> = {};
+    for (const key of Object.keys(r)) {
+      if (!knownKeys.has(key)) {
+        extras[key] = r[key];
+      }
+    }
+    if (Object.keys(extras).length > 0) req.extras = extras;
+
     return req;
   }
 
@@ -196,6 +211,16 @@ export class OpenAITransformer implements ProviderTransformer {
         function: { name: t.name, description: t.description, parameters: t.inputSchema },
       }));
     }
+
+    // Spread extras back into the outgoing request (response_format, logprobs, seed, etc.)
+    if (req.extras) {
+      for (const [key, value] of Object.entries(req.extras)) {
+        if (!(key in result)) {
+          result[key] = value;
+        }
+      }
+    }
+
     return result;
   }
 

--- a/tests/transforms.test.ts
+++ b/tests/transforms.test.ts
@@ -347,3 +347,110 @@ describe('Cross-provider transforms with Gemini and Ollama', () => {
 		expect(usage.output_tokens).toBe(5);
 	});
 });
+
+describe('Extras passthrough (response_format, etc.)', () => {
+	const openai = new OpenAITransformer();
+
+	it('captures response_format into extras during toCanonical', () => {
+		const raw = {
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'List 3 colors' }],
+			response_format: {
+				type: 'json_schema',
+				json_schema: {
+					name: 'ColorList',
+					strict: true,
+					schema: {
+						type: 'object',
+						properties: { colors: { type: 'array', items: { type: 'string' } } },
+						required: ['colors'],
+					},
+				},
+			},
+		};
+
+		const canonical = openai.toCanonical(raw);
+		expect(canonical.extras).toBeDefined();
+		expect(canonical.extras!.response_format).toEqual(raw.response_format);
+	});
+
+	it('round-trips response_format through toCanonical → fromCanonical', () => {
+		const raw = {
+			model: 'mercury-2',
+			messages: [{ role: 'user', content: 'List 3 colors' }],
+			response_format: {
+				type: 'json_schema',
+				json_schema: {
+					name: 'ColorList',
+					strict: true,
+					schema: {
+						type: 'object',
+						properties: { colors: { type: 'array', items: { type: 'string' } } },
+						required: ['colors'],
+					},
+				},
+			},
+		};
+
+		const canonical = openai.toCanonical(raw);
+		const output = openai.fromCanonical(canonical) as Record<string, unknown>;
+		expect(output.response_format).toEqual(raw.response_format);
+	});
+
+	it('round-trips multiple passthrough fields (seed, logprobs, frequency_penalty)', () => {
+		const raw = {
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hi' }],
+			temperature: 0.5,
+			seed: 42,
+			logprobs: true,
+			top_logprobs: 3,
+			frequency_penalty: 0.8,
+			presence_penalty: 0.2,
+			user: 'user-123',
+		};
+
+		const canonical = openai.toCanonical(raw);
+		expect(canonical.temperature).toBe(0.5);
+		expect(canonical.extras?.seed).toBe(42);
+		expect(canonical.extras?.logprobs).toBe(true);
+		expect(canonical.extras?.top_logprobs).toBe(3);
+		expect(canonical.extras?.frequency_penalty).toBe(0.8);
+
+		const output = openai.fromCanonical(canonical) as Record<string, unknown>;
+		expect(output.temperature).toBe(0.5);
+		expect(output.seed).toBe(42);
+		expect(output.logprobs).toBe(true);
+		expect(output.top_logprobs).toBe(3);
+		expect(output.frequency_penalty).toBe(0.8);
+		expect(output.presence_penalty).toBe(0.2);
+		expect(output.user).toBe('user-123');
+	});
+
+	it('does not put known fields into extras', () => {
+		const raw = {
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hi' }],
+			temperature: 0.5,
+			max_tokens: 100,
+			stream: true,
+		};
+
+		const canonical = openai.toCanonical(raw);
+		expect(canonical.extras).toBeUndefined();
+	});
+
+	it('extras do not overwrite explicitly mapped fields in fromCanonical', () => {
+		const canonical: CanonicalRequest = {
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hi' }],
+			temperature: 0.7,
+			extras: { temperature: 999, model: 'evil-model', response_format: { type: 'json_object' } },
+		};
+
+		const output = openai.fromCanonical(canonical) as Record<string, unknown>;
+		expect(output.temperature).toBe(0.7);
+		expect(output.model).toBe('gpt-4o');
+		expect(output.response_format).toEqual({ type: 'json_object' });
+	});
+});


### PR DESCRIPTION
Addresses issue #56

## Problem
`response_format` (and other passthrough fields like `logprobs`, `seed`, `frequency_penalty`, etc.) were stripped during the canonical request transformation, breaking structured output completely.

## Solution
Added an `extras?: Record<string, unknown>` field to `CanonicalRequest` that captures all unrecognized fields from incoming requests and spreads them back into outgoing requests. This is applied to all four transformers (OpenAI, Anthropic, Gemini, Ollama).

Known fields (model, messages, temperature, etc.) are mapped explicitly as before. Everything else goes into `extras` and round-trips cleanly.

## Changes
- `src/core/types.ts` — Added `extras` field to `CanonicalRequest`
- `src/proxy/transforms/openai.ts` — Capture extras in `toCanonical`, spread in `fromCanonical`
- `src/proxy/transforms/anthropic.ts` — Same
- `src/proxy/transforms/gemini.ts` — Same
- `src/proxy/transforms/ollama.ts` — Same
- `tests/transforms.test.ts` — Added 5 tests covering response_format passthrough, multiple extras, known-field exclusion, and collision safety

All 392 tests pass.