### PR TITLE
fix: measure upstream provider latency instead of internal pipeline time

### DIFF
--- a/src/middleware/log-request.ts
+++ b/src/middleware/log-request.ts
@@ -1,7 +1,10 @@
 import type { Middleware } from '../core/pipeline';
 
 /**
- * Log request/response summary: model, tokens, latency, provider, status.
+ * Log request start and pipeline timing. The full request completion log
+ * (including upstream provider latency) is handled by the router after
+ * the provider call returns, since this middleware only wraps the
+ * pre-flight pipeline — not the upstream HTTP call.
  */
 export function createLogMiddleware(): Middleware {
   return async function logRequest(ctx, next) {
@@ -15,17 +18,26 @@ export function createLogMiddleware(): Middleware {
     try {
       await next();
 
-      const latency = Date.now() - start;
-      ctx.log.info('request completed', {
-        model: ctx.response?.model ?? ctx.request.model,
-        provider: ctx.metadata.get('provider') as string,
-        latency,
-        inputTokens: ctx.response?.usage?.inputTokens,
-        outputTokens: ctx.response?.usage?.outputTokens,
-        stopReason: ctx.response?.stopReason,
-      });
+      const pipelineMs = Date.now() - start;
+      ctx.metadata.set('pipelineMs', pipelineMs);
 
-      ctx.metrics.histogram('request.latency_ms', latency);
+      // If the pipeline itself produced a response (e.g. cache hit),
+      // log completion here since the router won't make a provider call.
+      if (ctx.response) {
+        ctx.log.info('request completed', {
+          model: ctx.response.model ?? ctx.request.model,
+          provider: ctx.metadata.get('provider') as string,
+          latency: pipelineMs,
+          latency_total_ms: pipelineMs,
+          inputTokens: ctx.response.usage?.inputTokens,
+          outputTokens: ctx.response.usage?.outputTokens,
+          stopReason: ctx.response.stopReason,
+          source: 'pipeline',
+        });
+
+        ctx.metrics.histogram('request.latency_ms', pipelineMs);
+      }
+
       if (ctx.response?.usage) {
         ctx.metrics.counter('request.input_tokens', ctx.response.usage.inputTokens);
         ctx.metrics.counter('request.output_tokens', ctx.response.usage.outputTokens);

--- a/src/proxy/provider.test.ts
+++ b/src/proxy/provider.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { callProvider, callProviderStream } from './provider';
+import { createTimeoutBudget } from '../core/timeout';
+import type { ProviderTransformer } from './transform-registry';
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'http';
+
+/**
+ * Minimal transformer that passes data through for testing latency measurement.
+ */
+const stubTransformer: ProviderTransformer = {
+  provider: 'openai',
+  toCanonical: (body: unknown) => body as any,
+  fromCanonical: (req: unknown) => req as any,
+  responseToCanonical: (raw: any) => ({
+    model: raw.model ?? 'test',
+    messages: [],
+    choices: raw.choices ?? [{ message: { role: 'assistant', content: 'ok' }, index: 0 }],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    stopReason: 'stop',
+  }),
+  responseFromCanonical: (res: unknown) => res as any,
+  streamChunkToCanonical: (raw: any) => {
+    if (raw.choices?.[0]?.delta?.content) {
+      return { type: 'delta' as const, content: raw.choices[0].delta.content };
+    }
+    return null;
+  },
+};
+
+let server: Server;
+let baseUrl: string;
+const FAKE_DELAY_MS = 50;
+
+beforeAll(async () => {
+  server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? '';
+
+    if (url.includes('/v1/chat/completions')) {
+      let body = '';
+      req.on('data', (chunk) => (body += chunk));
+      req.on('end', () => {
+        const parsed = JSON.parse(body);
+
+        // Simulate network + inference delay
+        setTimeout(() => {
+          if (parsed.stream) {
+            res.writeHead(200, {
+              'Content-Type': 'text/event-stream',
+              'Cache-Control': 'no-cache',
+              Connection: 'keep-alive',
+            });
+
+            // Send first chunk after delay
+            setTimeout(() => {
+              res.write(
+                'data: ' +
+                  JSON.stringify({
+                    choices: [{ delta: { content: 'Hello' }, index: 0 }],
+                  }) +
+                  '\n\n'
+              );
+
+              // Send second chunk
+              setTimeout(() => {
+                res.write(
+                  'data: ' +
+                    JSON.stringify({
+                      choices: [{ delta: { content: ' world' }, index: 0 }],
+                    }) +
+                    '\n\n'
+                );
+                res.write('data: [DONE]\n\n');
+                res.end();
+              }, 20);
+            }, FAKE_DELAY_MS);
+          } else {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(
+              JSON.stringify({
+                model: 'test-model',
+                choices: [
+                  { message: { role: 'assistant', content: 'Hello' }, index: 0, finish_reason: 'stop' },
+                ],
+                usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+              })
+            );
+          }
+        }, FAKE_DELAY_MS);
+      });
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (addr && typeof addr === 'object') {
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('callProvider latency measurement', () => {
+  it('should measure realistic upstream latency for non-streaming calls', async () => {
+    const result = await callProvider({
+      providerConfig: {
+        name: 'test-provider',
+        baseUrl,
+        apiKey: 'test-key',
+        models: ['test-model'],
+        enabled: true,
+      },
+      transformer: stubTransformer,
+      body: { model: 'test-model', messages: [{ role: 'user', content: 'hi' }] },
+      timeout: createTimeoutBudget(10000),
+    });
+
+    // Latency should be at least the fake delay
+    expect(result.latencyMs).toBeGreaterThanOrEqual(FAKE_DELAY_MS - 5);
+    expect(result.latencyMs).toBeLessThan(5000);
+    expect(result.provider).toBe('test-provider');
+  });
+
+  it('should measure upstream latency and TTFB for streaming calls', async () => {
+    const result = await callProviderStream({
+      providerConfig: {
+        name: 'test-provider',
+        baseUrl,
+        apiKey: 'test-key',
+        models: ['test-model'],
+        enabled: true,
+      },
+      transformer: stubTransformer,
+      body: { model: 'test-model', messages: [{ role: 'user', content: 'hi' }], stream: true },
+      timeout: createTimeoutBudget(10000),
+    });
+
+    // HTTP response latency (headers received)
+    expect(result.latencyMs).toBeGreaterThanOrEqual(FAKE_DELAY_MS - 5);
+    expect(result.provider).toBe('test-provider');
+
+    // Consume chunks to populate ttfbMs
+    const chunks: unknown[] = [];
+    for await (const chunk of result.chunks) {
+      chunks.push(chunk);
+    }
+
+    // Should have received content chunks + done
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+
+    // TTFB should be >= HTTP latency (first chunk comes after HTTP headers + additional delay)
+    expect(result.ttfbMs).toBeGreaterThanOrEqual(FAKE_DELAY_MS - 5);
+    // TTFB should be different from latencyMs since there's extra delay for first chunk
+    expect(result.ttfbMs).toBeGreaterThanOrEqual(result.latencyMs);
+  });
+});

--- a/src/proxy/provider.ts
+++ b/src/proxy/provider.ts
@@ -24,7 +24,10 @@ export interface ProviderCallResult {
 
 export interface ProviderStreamResult {
   chunks: AsyncIterableIterator<CanonicalStreamChunk>;
+  /** Time from request start until HTTP response headers received */
   latencyMs: number;
+  /** Time from request start until first parsed SSE chunk yielded */
+  ttfbMs: number;
   provider: string;
 }
 
@@ -183,6 +186,7 @@ export async function callProviderStream(opts: ProviderCallOptions): Promise<Pro
 
   const decoder = new TextDecoder();
   let buffer = '';
+  let firstChunkMs = 0;
 
   async function* parseSSE(): AsyncIterableIterator<CanonicalStreamChunk> {
     while (true) {
@@ -207,7 +211,10 @@ export async function callProviderStream(opts: ProviderCallOptions): Promise<Pro
           try {
             const parsed = JSON.parse(data);
             const chunk = transformer.streamChunkToCanonical(parsed);
-            if (chunk) yield chunk;
+            if (chunk) {
+              if (!firstChunkMs) firstChunkMs = Date.now() - start;
+              yield chunk;
+            }
           } catch {
             // Skip malformed JSON
           }
@@ -219,9 +226,15 @@ export async function callProviderStream(opts: ProviderCallOptions): Promise<Pro
     }
   }
 
+  const httpLatencyMs = Date.now() - start;
+
   return {
     chunks: parseSSE(),
-    latencyMs: Date.now() - start,
+    latencyMs: httpLatencyMs,
+    get ttfbMs() {
+      // Returns first chunk time once available, falls back to HTTP response time
+      return firstChunkMs || httpLatencyMs;
+    },
     provider: providerConfig.name,
   };
 }

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -127,8 +127,26 @@ export function setupRoutes(app: Express, opts: RouterOptions) {
           });
 
           if ('chunks' in result) {
-            setResponseHeaders(res, reqId, result.provider, result.latencyMs);
+            const preStreamMs = Date.now() - startTime;
+            setResponseHeaders(res, reqId, result.provider, preStreamMs);
+            res.setHeader('X-Prism-Upstream-Latency', String(Math.round(result.latencyMs)));
+
             await writeSSEStream(res, result.chunks, clientTransformer);
+
+            const totalMs = Date.now() - startTime;
+            ctx.log.info('request completed', {
+              model: ctx.request.model,
+              provider: result.provider,
+              latency: totalMs,
+              latency_upstream_ms: Math.round(result.latencyMs),
+              latency_ttfb_ms: Math.round(result.ttfbMs),
+              latency_total_ms: totalMs,
+              stream: true,
+            });
+            ctx.metrics.histogram('request.latency_ms', totalMs);
+            ctx.metrics.histogram('request.upstream_latency_ms', result.latencyMs);
+            ctx.metrics.histogram('request.ttfb_ms', result.ttfbMs);
+
             return;
           }
         }
@@ -145,11 +163,27 @@ export function setupRoutes(app: Express, opts: RouterOptions) {
           ctx.response = result.response;
           ctx.metadata.set('provider', result.provider);
 
+          const totalMs = Date.now() - startTime;
           const serialized = clientTransformer.responseFromCanonical(result.response);
-          setResponseHeaders(res, reqId, result.provider, Date.now() - startTime);
+          setResponseHeaders(res, reqId, result.provider, totalMs);
+          res.setHeader('X-Prism-Upstream-Latency', String(Math.round(result.latencyMs)));
           if (providers.length > 1 && result.provider !== primaryProvider.config.name) {
             res.setHeader('X-Prism-Fallback-Used', 'true');
           }
+
+          ctx.log.info('request completed', {
+            model: ctx.response.model ?? ctx.request.model,
+            provider: result.provider,
+            latency: totalMs,
+            latency_upstream_ms: Math.round(result.latencyMs),
+            latency_total_ms: totalMs,
+            inputTokens: ctx.response.usage?.inputTokens,
+            outputTokens: ctx.response.usage?.outputTokens,
+            stopReason: ctx.response.stopReason,
+          });
+          ctx.metrics.histogram('request.latency_ms', totalMs);
+          ctx.metrics.histogram('request.upstream_latency_ms', result.latencyMs);
+
           res.json(serialized);
         }
       } catch (err) {


### PR DESCRIPTION
Addresses issue #58

## Problem
Latency logging showed 0ms for virtually every request because the log middleware only measured the pre-flight pipeline processing time, not the actual upstream provider HTTP round-trip.

## Root Cause
The `createLogMiddleware()` wraps the pipeline's `next()` call, but the pipeline runs **before** the provider call in `router.ts`. So `Date.now() - start` around `next()` measured ~0ms of pipeline transforms, not the network call.

## Fix
- Moved completion logging to `router.ts` where `callProvider`/`callProviderStream` results (with accurate timing from `provider.ts`) are available
- Added new log fields:
  - `latency_upstream_ms` — provider round-trip time (fetch to response)
  - `latency_total_ms` — full request lifecycle  
  - `latency_ttfb_ms` — time to first byte (streaming only)
- Added `X-Prism-Upstream-Latency` response header
- Log middleware now only logs for pipeline-served responses (e.g. cache hits)
- Preserved existing `latency` field (now shows `latency_total_ms` value)

## Tests
All 387 tests pass. Integration test output confirms realistic values.