### PR TITLE
feat: wire composition chains into route config (YAML support)

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -98,12 +98,47 @@ export function loadConfig(configPath?: string): ResolvedConfig {
 
   // Parse routes
   if (Array.isArray(rawConfig.routes)) {
-    config.routes = (rawConfig.routes as Array<Record<string, unknown>>).map((r) => ({
-      path: String(r.path),
-      providers: (r.providers as string[]) ?? [],
-      pipeline: r.pipeline as string[] | undefined,
-      systemPrompt: r.systemPrompt as string | undefined,
-    }));
+    config.routes = (rawConfig.routes as Array<Record<string, unknown>>).map((r) => {
+      const route: import('../core/types').RouteConfig = {
+        path: String(r.path),
+        providers: (r.providers as string[]) ?? [],
+        pipeline: r.pipeline as string[] | undefined,
+        systemPrompt: r.systemPrompt as string | undefined,
+      };
+
+      // Parse compose config
+      if (r.compose && typeof r.compose === 'object') {
+        const c = r.compose as Record<string, unknown>;
+        const composeType = String(c.type ?? 'chain');
+        if (composeType !== 'chain') {
+          throw new Error(`Unsupported compose type: "${composeType}". Only "chain" is supported.`);
+        }
+        const rawSteps = c.steps as Array<Record<string, unknown>> | undefined;
+        if (!Array.isArray(rawSteps) || rawSteps.length === 0) {
+          throw new Error(`Compose route "${route.path}" requires at least one step.`);
+        }
+        route.compose = {
+          type: 'chain',
+          steps: rawSteps.map((s) => {
+            if (!s.name || !s.provider) {
+              throw new Error(`Compose steps require "name" and "provider" fields.`);
+            }
+            return {
+              name: String(s.name),
+              provider: String(s.provider),
+              model: s.model ? String(s.model) : undefined,
+              systemPrompt: s.systemPrompt as string | undefined,
+              inputTransform: s.inputTransform as string | undefined,
+              timeout: s.timeout ? Number(s.timeout) : undefined,
+              onError: s.onError as 'fail' | 'skip' | 'default' | 'partial' | undefined,
+              defaultContent: s.defaultContent as string | undefined,
+            };
+          }),
+        };
+      }
+
+      return route;
+    });
   }
 
   return config;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -175,11 +175,28 @@ export interface ProviderConfig {
   timeout?: number;
 }
 
+export interface ComposeStepConfig {
+  name: string;
+  provider: string;
+  model?: string;
+  systemPrompt?: string;
+  inputTransform?: string;
+  timeout?: number;
+  onError?: 'fail' | 'skip' | 'default' | 'partial';
+  defaultContent?: string;
+}
+
+export interface ComposeConfig {
+  type: 'chain';
+  steps: ComposeStepConfig[];
+}
+
 export interface RouteConfig {
   path: string;
   providers: string[];
   pipeline?: string[];
   systemPrompt?: string;
+  compose?: ComposeConfig;
 }
 
 export interface ResolvedConfig {

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,10 +1,13 @@
 import type { Express, Request, Response } from 'express';
+import { ChainComposer } from '../compose/chain';
+import type { CallProviderFn, CompositionStep } from '../core/composer';
 import { PipelineContext } from '../core/context';
 import type { PipelineEngine } from '../core/pipeline';
 import { createTimeoutBudget } from '../core/timeout';
-import type { CanonicalRequest, ResolvedConfig } from '../core/types';
+import type { CanonicalRequest, ComposeStepConfig, ResolvedConfig } from '../core/types';
 import { PipelineError } from '../core/types';
 import { executeFallbackChain } from '../fallback/chain';
+import { callProvider as rawCallProvider } from '../proxy/provider';
 import { writeSSEStream } from '../proxy/stream';
 import type { TransformRegistry } from '../proxy/transform-registry';
 
@@ -110,6 +113,81 @@ export function setupRoutes(app: Express, opts: RouterOptions) {
           const serialized = clientTransformer.responseFromCanonical(ctx.response);
           setResponseHeaders(res, reqId, primaryProvider.config.name, Date.now() - startTime);
           res.json(serialized);
+          return;
+        }
+
+        // ─── Compose route handling ───
+        if (route.compose) {
+          const composer = new ChainComposer();
+
+          // Build CallProviderFn that resolves provider by name
+          const callProviderFn: CallProviderFn = async (request, providerName, timeout) => {
+            const providerCfg = config.providers[providerName];
+            if (!providerCfg) {
+              throw new PipelineError(
+                `Unknown provider "${providerName}" in compose step`,
+                'invalid_request',
+                'compose_router',
+                400,
+              );
+            }
+            const format =
+              providerCfg.format ??
+              (providerCfg.baseUrl.includes('anthropic') ? 'anthropic' : undefined) ??
+              (providerCfg.baseUrl.includes('openai') ? 'openai' : undefined) ??
+              clientFormat;
+            const transformer = transformRegistry.has(format)
+              ? transformRegistry.get(format)
+              : clientTransformer;
+
+            const providerBody = transformer.fromCanonical(request);
+            const result = await rawCallProvider({
+              providerConfig: providerCfg,
+              transformer,
+              body: providerBody,
+              timeout,
+            });
+            return result.response;
+          };
+
+          // Map config steps to CompositionStep[]
+          const steps: CompositionStep[] = route.compose.steps.map((s: ComposeStepConfig) => ({
+            name: s.name,
+            provider: s.provider,
+            model: s.model,
+            systemPrompt: s.systemPrompt,
+            inputTransform: s.inputTransform,
+            timeout: s.timeout,
+            onError: s.onError,
+            defaultContent: s.defaultContent,
+          }));
+
+          const result = await composer.execute(ctx, steps, callProviderFn);
+
+          const totalMs = Date.now() - startTime;
+          if (result.finalResponse) {
+            const serialized = clientTransformer.responseFromCanonical(result.finalResponse);
+            setResponseHeaders(res, reqId, 'compose', totalMs);
+            res.setHeader('X-Prism-Compose-Steps', String(result.steps.length));
+            res.json(serialized);
+          } else {
+            // Partial/errored — build a text response from last successful step
+            const lastSuccess = [...result.steps].reverse().find((s) => s.status === 'success' || s.status === 'defaulted');
+            setResponseHeaders(res, reqId, 'compose', totalMs);
+            res.setHeader('X-Prism-Compose-Steps', String(result.steps.length));
+            res.json({
+              id: `compose-${reqId}`,
+              model: 'compose',
+              content: [{ type: 'text', text: lastSuccess?.content ?? '' }],
+              stop_reason: 'end',
+              usage: { input_tokens: 0, output_tokens: 0 },
+            });
+          }
+
+          ctx.log.info('compose request completed', {
+            steps: result.steps.map((s) => ({ name: s.name, status: s.status, ms: s.durationMs })),
+            totalMs,
+          });
           return;
         }
 

--- a/tests/unit/config/compose-loader.test.ts
+++ b/tests/unit/config/compose-loader.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { loadConfig } from '../../../src/config/loader';
+
+const TEST_CONFIG = 'test-compose-config.yaml';
+
+function cleanup() {
+  if (existsSync(TEST_CONFIG)) unlinkSync(TEST_CONFIG);
+}
+
+describe('Config loader: compose routes', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it('parses a compose route with chain steps', () => {
+    writeFileSync(
+      TEST_CONFIG,
+      `
+providers:
+  opus:
+    baseUrl: https://api.anthropic.com
+    apiKey: test-key
+  mercury:
+    baseUrl: https://api.openai.com
+    apiKey: test-key-2
+routes:
+  - path: /v1/chain/test
+    compose:
+      type: chain
+      steps:
+        - name: planner
+          provider: opus
+          model: claude-opus-4-6-20250624
+          systemPrompt: "You are a planner"
+          inputTransform: "{{original.lastUserMessage}}"
+          timeout: 60000
+        - name: executor
+          provider: mercury
+          model: mercury-2
+          inputTransform: "{{steps.planner.content}}"
+          timeout: 30000
+`,
+    );
+
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.routes).toHaveLength(1);
+
+    const route = config.routes[0];
+    expect(route.path).toBe('/v1/chain/test');
+    expect(route.compose).toBeDefined();
+    expect(route.compose!.type).toBe('chain');
+    expect(route.compose!.steps).toHaveLength(2);
+
+    const [step1, step2] = route.compose!.steps;
+    expect(step1.name).toBe('planner');
+    expect(step1.provider).toBe('opus');
+    expect(step1.model).toBe('claude-opus-4-6-20250624');
+    expect(step1.systemPrompt).toBe('You are a planner');
+    expect(step1.inputTransform).toBe('{{original.lastUserMessage}}');
+    expect(step1.timeout).toBe(60000);
+
+    expect(step2.name).toBe('executor');
+    expect(step2.provider).toBe('mercury');
+    expect(step2.inputTransform).toBe('{{steps.planner.content}}');
+  });
+
+  it('leaves compose undefined for non-compose routes', () => {
+    writeFileSync(
+      TEST_CONFIG,
+      `
+providers:
+  openai:
+    baseUrl: https://api.openai.com
+    apiKey: test-key
+routes:
+  - path: /v1/chat/completions
+    providers: [openai]
+`,
+    );
+
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.routes[0].compose).toBeUndefined();
+  });
+
+  it('throws on unsupported compose type', () => {
+    writeFileSync(
+      TEST_CONFIG,
+      `
+routes:
+  - path: /test
+    compose:
+      type: parallel
+      steps:
+        - name: a
+          provider: x
+`,
+    );
+
+    expect(() => loadConfig(TEST_CONFIG)).toThrow('Unsupported compose type');
+  });
+
+  it('throws when compose steps are empty', () => {
+    writeFileSync(
+      TEST_CONFIG,
+      `
+routes:
+  - path: /test
+    compose:
+      type: chain
+      steps: []
+`,
+    );
+
+    expect(() => loadConfig(TEST_CONFIG)).toThrow('requires at least one step');
+  });
+
+  it('throws when step is missing name or provider', () => {
+    writeFileSync(
+      TEST_CONFIG,
+      `
+routes:
+  - path: /test
+    compose:
+      type: chain
+      steps:
+        - name: step1
+`,
+    );
+
+    expect(() => loadConfig(TEST_CONFIG)).toThrow('require "name" and "provider"');
+  });
+});


### PR DESCRIPTION
Addresses issue #63

## Changes

- **types.ts**: Added `ComposeConfig` and `ComposeStepConfig` types to `RouteConfig`
- **loader.ts**: Parse `compose` key from YAML with validation (type check, step validation, required fields)
- **router.ts**: When a route has `compose`, use `ChainComposer` with per-step provider resolution instead of the fallback chain
- **Tests**: Added 5 config loader tests for compose route parsing (valid config, non-compose routes, error cases)

## How it works

Routes with a `compose` key bypass the normal fallback chain. Instead, the router:
1. Creates a `CallProviderFn` that resolves providers by name from config
2. Maps YAML step configs to `CompositionStep[]`
3. Executes via `ChainComposer` with template resolution between steps

All 399 tests pass. Existing non-compose routes are completely unaffected.