### PR TITLE
feat: add programmatic library API — createPrismPipe() factory

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,18 @@
   "version": "0.1.0",
   "description": "AI proxy with configurable rate limiting, fallbacks, logging, and multi-IP egress",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/lib.js",
+  "types": "dist/lib.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/lib.js",
+      "types": "./dist/lib.d.ts"
+    },
+    "./config": {
+      "import": "./dist/config/loader.js",
+      "types": "./dist/config/loader.d.ts"
+    }
+  },
   "bin": {
     "prism-pipe": "dist/cli/index.js"
   },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,6 @@ const args = process.argv.slice(2);
 if (args.includes('install') || args.includes('uninstall')) {
   parseInstallArgs(args);
 } else {
-  // Default: boot the server
+  // Default: boot the server via the script entry point
   await import('../index.js');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,130 +1,50 @@
-import pino from 'pino';
+/**
+ * Script entry point — loads YAML config and boots a PrismPipe instance.
+ * For programmatic use, import { createPrismPipe } from 'prism-pipe' instead.
+ */
+
 import { loadConfig } from './config/loader';
-import { PipelineEngine } from './core/pipeline';
-import type { ResolvedConfig } from './core/types';
-import { createLogMiddleware } from './middleware/log-request';
-import { createTransformMiddleware } from './middleware/transform-format';
-import { TransformRegistry } from './proxy/transform-registry';
-import { AnthropicTransformer } from './proxy/transforms/anthropic';
-import { OpenAITransformer } from './proxy/transforms/openai';
-import { TokenBucket } from './rate-limit/token-bucket';
-import { createAuthMiddleware } from './server/auth';
-import { createApp, errorHandler } from './server/express';
-import { createRateLimitMiddleware } from './server/rate-limit';
-import { setupRoutes } from './server/router';
-import type { Store } from './store/interface';
-import { MemoryStore } from './store/memory';
-import { SQLiteStore } from './store/sqlite';
+import { createPrismPipe } from './lib';
 
-// ── Load config ──
-const config: ResolvedConfig = loadConfig();
+const config = loadConfig(process.env.PRISM_CONFIG);
 
-// ── Logger ──
-const logger = pino({
-  level: config.logLevel,
-  transport: process.stdout.isTTY
-    ? { target: 'pino-pretty', options: { colorize: true } }
-    : undefined,
+const proxy = createPrismPipe({
+  port: config.port,
+  logLevel: config.logLevel,
+  requestTimeout: config.requestTimeout,
+  providers: Object.fromEntries(
+    Object.entries(config.providers).map(([name, p]) => [
+      name,
+      {
+        baseUrl: p.baseUrl,
+        apiKey: p.apiKey,
+        format: p.format,
+        models: p.models,
+        defaultModel: p.defaultModel,
+        timeout: p.timeout,
+      },
+    ]),
+  ),
+  routes: config.routes,
+  apiKeys: process.env.PRISM_API_KEYS?.split(',')
+    .map((k) => k.trim())
+    .filter(Boolean),
+  rateLimitRpm: Number(process.env.RATE_LIMIT_RPM ?? 60),
+  storeType: process.env.STORE_TYPE === 'memory' ? 'memory' : 'sqlite',
+  storePath: process.env.STORE_PATH,
 });
 
-// ── Store ──
-const store: Store =
-  process.env.STORE_TYPE === 'memory'
-    ? new MemoryStore()
-    : new SQLiteStore(process.env.STORE_PATH ?? './data/prism-pipe.db');
-
-// ── Transform registry ──
-const transformRegistry = new TransformRegistry();
-transformRegistry.register(new OpenAITransformer());
-transformRegistry.register(new AnthropicTransformer());
-
-// ── Pipeline ──
-const pipeline = new PipelineEngine();
-pipeline.use(createLogMiddleware());
-pipeline.use(createTransformMiddleware(transformRegistry));
-
-// ── Express app ──
-const app = createApp();
-
-// ── Auth middleware ──
-const apiKeys = process.env.PRISM_API_KEYS?.split(',')
-  .map((k) => k.trim())
-  .filter(Boolean);
-app.use(createAuthMiddleware(apiKeys));
-
-// ── Rate limit middleware ──
-const rateLimitCapacity = Number(process.env.RATE_LIMIT_RPM ?? 60);
-const bucket = new TokenBucket({
-  capacity: rateLimitCapacity,
-  refillRate: rateLimitCapacity / 60, // per second
-  store,
-});
-app.use(createRateLimitMiddleware(bucket));
-
-// ── /v1/models endpoint ──
-app.get('/v1/models', (_req, res) => {
-  const models = Object.entries(config.providers).flatMap(([providerName, provider]) => {
-    const providerModels = provider.models
-      ? Object.keys(provider.models)
-      : [provider.defaultModel ?? `${providerName}/default`];
-    return providerModels.map((model) => ({
-      id: model,
-      object: 'model' as const,
-      created: Math.floor(Date.now() / 1000),
-      owned_by: providerName,
-    }));
-  });
-
-  res.json({ object: 'list', data: models });
-});
-
-// ── Routes ──
-setupRoutes(app, { config, pipeline, transformRegistry });
-
-// ── Error handler (must be last) ──
-app.use(errorHandler);
-
-// ── Boot ──
-async function boot() {
-  await store.init();
-  logger.info('Store initialized');
-
-  const port = config.port;
-  const server = app.listen(port, () => {
-    const providerNames = Object.keys(config.providers);
-    const banner = [
-      '',
-      '  🔷 Prism Pipe v0.1.0',
-      `  ├─ Port:       ${port}`,
-      `  ├─ Providers:  ${providerNames.length > 0 ? providerNames.join(', ') : '(none)'}`,
-      `  ├─ Routes:     ${config.routes.map((r) => r.path).join(', ')}`,
-      `  ├─ Rate limit: ${rateLimitCapacity} req/min`,
-      `  ├─ Store:      ${store instanceof SQLiteStore ? 'SQLite' : 'Memory'}`,
-      `  ├─ Auth:       ${apiKeys?.length ? `${apiKeys.length} key(s)` : 'open (no keys)'}`,
-      `  └─ Log level:  ${config.logLevel}`,
-      '',
-    ];
-    for (const line of banner) logger.info(line);
-  });
-
-  // Graceful shutdown
-  function shutdown(signal: string) {
-    logger.info(`Received ${signal}, shutting down...`);
-    server.close(async () => {
-      await store.close();
-      logger.info('Server closed');
-      process.exit(0);
-    });
-    setTimeout(() => process.exit(1), 10_000).unref();
-  }
-
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
-  process.on('SIGINT', () => shutdown('SIGINT'));
-}
-
-boot().catch((err) => {
-  logger.fatal({ err }, 'Failed to start Prism Pipe');
+proxy.start().catch((err) => {
+  console.error('Failed to start Prism Pipe:', err);
   process.exit(1);
 });
 
-export { app };
+// Graceful shutdown
+function shutdown(signal: string) {
+  console.log(`Received ${signal}, shutting down...`);
+  proxy.stop().then(() => process.exit(0));
+  setTimeout(() => process.exit(1), 10_000).unref();
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createPrismPipe, type PrismPipe } from './lib';
+
+describe('createPrismPipe', () => {
+  it('returns an instance with expected interface', () => {
+    const proxy = createPrismPipe({ port: 0 });
+    expect(proxy).toHaveProperty('start');
+    expect(proxy).toHaveProperty('stop');
+    expect(proxy).toHaveProperty('port');
+    expect(proxy).toHaveProperty('app');
+    expect(proxy).toHaveProperty('health');
+    expect(typeof proxy.start).toBe('function');
+    expect(typeof proxy.stop).toBe('function');
+    expect(typeof proxy.health).toBe('function');
+  });
+
+  it('health() returns stopped status before start', () => {
+    const proxy = createPrismPipe({ port: 0 });
+    const h = proxy.health();
+    expect(h.status).toBe('stopped');
+    expect(h.providers).toEqual([]);
+  });
+
+  describe('running instance', () => {
+    let proxy: PrismPipe;
+
+    beforeAll(async () => {
+      proxy = await createPrismPipe({
+        port: 0, // random port
+        logLevel: 'silent',
+        storeType: 'memory',
+        providers: {
+          test: {
+            baseUrl: 'http://localhost:9999',
+            apiKey: 'test-key',
+          },
+        },
+        routes: [
+          {
+            path: '/v1/chat/completions',
+            providers: ['test'],
+          },
+        ],
+      }).start();
+    });
+
+    afterAll(async () => {
+      await proxy.stop();
+    });
+
+    it('listens on assigned port', () => {
+      expect(proxy.port).toBeGreaterThan(0);
+    });
+
+    it('health() returns healthy status', () => {
+      const h = proxy.health();
+      expect(h.status).toBe('healthy');
+      expect(h.providers).toEqual(['test']);
+    });
+
+    it('responds to /health', async () => {
+      const res = await fetch(`http://localhost:${proxy.port}/health`);
+      expect(res.ok).toBe(true);
+      const body = await res.json();
+      expect(body.status).toBe('ok');
+    });
+
+    it('responds to /v1/models', async () => {
+      const res = await fetch(`http://localhost:${proxy.port}/v1/models`);
+      expect(res.ok).toBe(true);
+      const body = await res.json();
+      expect(body.object).toBe('list');
+      expect(body.data).toBeInstanceOf(Array);
+    });
+  });
+
+  describe('multiple instances', () => {
+    let proxy1: PrismPipe;
+    let proxy2: PrismPipe;
+
+    beforeAll(async () => {
+      [proxy1, proxy2] = await Promise.all([
+        createPrismPipe({
+          port: 0,
+          logLevel: 'silent',
+          storeType: 'memory',
+        }).start(),
+        createPrismPipe({
+          port: 0,
+          logLevel: 'silent',
+          storeType: 'memory',
+        }).start(),
+      ]);
+    });
+
+    afterAll(async () => {
+      await Promise.all([proxy1.stop(), proxy2.stop()]);
+    });
+
+    it('run on different ports', () => {
+      expect(proxy1.port).not.toBe(proxy2.port);
+      expect(proxy1.port).toBeGreaterThan(0);
+      expect(proxy2.port).toBeGreaterThan(0);
+    });
+
+    it('both respond independently', async () => {
+      const [r1, r2] = await Promise.all([
+        fetch(`http://localhost:${proxy1.port}/health`),
+        fetch(`http://localhost:${proxy2.port}/health`),
+      ]);
+      expect(r1.ok).toBe(true);
+      expect(r2.ok).toBe(true);
+    });
+  });
+});

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,307 @@
+/**
+ * Programmatic API for Prism Pipe.
+ *
+ * @example
+ * ```typescript
+ * import { createPrismPipe } from 'prism-pipe';
+ *
+ * const proxy = createPrismPipe({
+ *   port: 3100,
+ *   providers: {
+ *     openai: { baseUrl: 'https://api.openai.com', apiKey: '...' },
+ *   },
+ *   routes: [{ path: '/v1/chat/completions', providers: ['openai'] }],
+ * });
+ *
+ * await proxy.start();
+ * // ...
+ * await proxy.stop();
+ * ```
+ */
+
+import type { Express } from 'express';
+import type { Server } from 'node:http';
+import pino from 'pino';
+import { PipelineEngine } from './core/pipeline';
+import type {
+  ComposeConfig,
+  ProviderConfig,
+  ResolvedConfig,
+  RouteConfig,
+} from './core/types';
+import { createLogMiddleware } from './middleware/log-request';
+import { createTransformMiddleware } from './middleware/transform-format';
+import { TransformRegistry } from './proxy/transform-registry';
+import { AnthropicTransformer } from './proxy/transforms/anthropic';
+import { OpenAITransformer } from './proxy/transforms/openai';
+import { TokenBucket } from './rate-limit/token-bucket';
+import { createAuthMiddleware } from './server/auth';
+import { createApp, errorHandler } from './server/express';
+import { createRateLimitMiddleware } from './server/rate-limit';
+import { setupRoutes } from './server/router';
+import type { Store } from './store/interface';
+import { MemoryStore } from './store/memory';
+import { SQLiteStore } from './store/sqlite';
+
+// ─── Public Types ───
+
+export interface PrismPipeProviderConfig {
+  baseUrl: string;
+  apiKey: string;
+  format?: string;
+  models?: Record<string, string>;
+  defaultModel?: string;
+  timeout?: number;
+}
+
+export interface PrismPipeComposeStepConfig {
+  name: string;
+  provider: string;
+  model?: string;
+  systemPrompt?: string;
+  inputTransform?: string;
+  timeout?: number;
+  onError?: 'fail' | 'skip' | 'default' | 'partial';
+  defaultContent?: string;
+}
+
+export interface PrismPipeComposeConfig {
+  type: 'chain';
+  steps: PrismPipeComposeStepConfig[];
+}
+
+export interface PrismPipeRouteConfig {
+  path: string;
+  providers?: string[];
+  pipeline?: string[];
+  systemPrompt?: string;
+  compose?: PrismPipeComposeConfig;
+}
+
+export interface PrismPipeConfig {
+  /** Port to listen on. Defaults to 3000. */
+  port?: number;
+  /** Log level. Defaults to 'info'. */
+  logLevel?: string;
+  /** Request timeout in ms. Defaults to 120000. */
+  requestTimeout?: number;
+  /** Provider configurations keyed by name. */
+  providers?: Record<string, PrismPipeProviderConfig>;
+  /** Route configurations. */
+  routes?: PrismPipeRouteConfig[];
+  /** API keys for auth. If empty, auth is disabled. */
+  apiKeys?: string[];
+  /** Rate limit requests per minute. Defaults to 60. */
+  rateLimitRpm?: number;
+  /** Store type: 'memory' or 'sqlite'. Defaults to 'memory'. */
+  storeType?: 'memory' | 'sqlite';
+  /** SQLite store path. Only used when storeType is 'sqlite'. */
+  storePath?: string;
+}
+
+export interface PrismPipe {
+  /** Start the server. Returns the instance for chaining. */
+  start(): Promise<PrismPipe>;
+  /** Stop the server gracefully. */
+  stop(): Promise<void>;
+  /** The port the server is listening on. */
+  readonly port: number;
+  /** The underlying Express app. */
+  readonly app: Express;
+  /** Health check info. */
+  health(): { status: string; uptime: number; providers: string[] };
+}
+
+// ─── Factory ───
+
+export function createPrismPipe(config: PrismPipeConfig = {}): PrismPipe {
+  const resolvedConfig = resolveConfig(config);
+  const startedAt = Date.now();
+
+  // Logger
+  const logger = pino({
+    level: resolvedConfig.logLevel,
+    transport: process.stdout.isTTY
+      ? { target: 'pino-pretty', options: { colorize: true } }
+      : undefined,
+  });
+
+  // Store
+  const store: Store =
+    config.storeType === 'sqlite'
+      ? new SQLiteStore(config.storePath ?? './data/prism-pipe.db')
+      : new MemoryStore();
+
+  // Transform registry
+  const transformRegistry = new TransformRegistry();
+  transformRegistry.register(new OpenAITransformer());
+  transformRegistry.register(new AnthropicTransformer());
+
+  // Pipeline
+  const pipeline = new PipelineEngine();
+  pipeline.use(createLogMiddleware());
+  pipeline.use(createTransformMiddleware(transformRegistry));
+
+  // Express app
+  const app = createApp();
+
+  // Auth
+  if (config.apiKeys && config.apiKeys.length > 0) {
+    app.use(createAuthMiddleware(config.apiKeys));
+  }
+
+  // Rate limit
+  const rpm = config.rateLimitRpm ?? 60;
+  const bucket = new TokenBucket({
+    capacity: rpm,
+    refillRate: rpm / 60,
+    store,
+  });
+  app.use(createRateLimitMiddleware(bucket));
+
+  // /v1/models endpoint
+  app.get('/v1/models', (_req, res) => {
+    const models = Object.entries(resolvedConfig.providers).flatMap(
+      ([providerName, provider]) => {
+        const providerModels = provider.models
+          ? Object.keys(provider.models)
+          : [provider.defaultModel ?? `${providerName}/default`];
+        return providerModels.map((model) => ({
+          id: model,
+          object: 'model' as const,
+          created: Math.floor(Date.now() / 1000),
+          owned_by: providerName,
+        }));
+      },
+    );
+    res.json({ object: 'list', data: models });
+  });
+
+  // Routes
+  setupRoutes(app, { config: resolvedConfig, pipeline, transformRegistry });
+
+  // Error handler (last)
+  app.use(errorHandler);
+
+  let server: Server | null = null;
+  let actualPort: number = resolvedConfig.port;
+
+  const instance: PrismPipe = {
+    get port() {
+      return actualPort;
+    },
+    get app() {
+      return app;
+    },
+
+    health() {
+      return {
+        status: server ? 'healthy' : 'stopped',
+        uptime: Math.floor((Date.now() - startedAt) / 1000),
+        providers: Object.keys(resolvedConfig.providers),
+      };
+    },
+
+    async start() {
+      await store.init();
+
+      return new Promise<PrismPipe>((resolve, reject) => {
+        try {
+          server = app.listen(resolvedConfig.port, () => {
+            const addr = server!.address();
+            if (addr && typeof addr === 'object') {
+              actualPort = addr.port;
+            }
+            logger.info(`Prism Pipe listening on port ${actualPort}`);
+            resolve(instance);
+          });
+          server.on('error', reject);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    },
+
+    async stop() {
+      if (!server) return;
+      return new Promise<void>((resolve, reject) => {
+        server!.close(async (err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          await store.close();
+          server = null;
+          logger.info('Prism Pipe stopped');
+          resolve();
+        });
+      });
+    },
+  };
+
+  return instance;
+}
+
+// ─── Config Resolution ───
+
+function resolveConfig(config: PrismPipeConfig): ResolvedConfig {
+  const providers: Record<string, ProviderConfig> = {};
+
+  if (config.providers) {
+    for (const [name, p] of Object.entries(config.providers)) {
+      providers[name] = {
+        name,
+        baseUrl: p.baseUrl,
+        apiKey: p.apiKey,
+        format: p.format,
+        models: p.models,
+        defaultModel: p.defaultModel,
+        timeout: p.timeout,
+      };
+    }
+  }
+
+  const routes: RouteConfig[] = (config.routes ?? []).map((r) => {
+    const route: RouteConfig = {
+      path: r.path,
+      providers: r.providers ?? [],
+      pipeline: r.pipeline,
+      systemPrompt: r.systemPrompt,
+    };
+    if (r.compose) {
+      route.compose = r.compose as ComposeConfig;
+    }
+    return route;
+  });
+
+  // Default route if none provided
+  if (routes.length === 0) {
+    routes.push({
+      path: '/v1/chat/completions',
+      providers: Object.keys(providers),
+      pipeline: ['log-request', 'transform-format'],
+    });
+  }
+
+  return {
+    port: config.port ?? 3000,
+    logLevel: config.logLevel ?? 'info',
+    requestTimeout: config.requestTimeout ?? 120_000,
+    providers,
+    routes,
+  };
+}
+
+// ─── Re-exports ───
+
+export { loadConfig } from './config/loader';
+export type {
+  CanonicalRequest,
+  CanonicalResponse,
+  CanonicalStreamChunk,
+  ComposeConfig,
+  ComposeStepConfig,
+  ProviderConfig,
+  ResolvedConfig,
+  RouteConfig,
+} from './core/types';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/cli/index.ts'],
+  entry: ['src/lib.ts', 'src/index.ts', 'src/cli/index.ts'],
   format: ['esm'],
   outDir: 'dist',
   splitting: true,


### PR DESCRIPTION
Addresses issue #66

## Changes

- **`src/lib.ts`** — New `createPrismPipe(config)` factory that returns a `PrismPipe` instance with `.start()`, `.stop()`, `.port`, `.app`, and `.health()` methods
- **`src/index.ts`** — Refactored to a thin wrapper: loads YAML config → creates instance via factory → starts
- **`src/cli/index.ts`** — Still delegates to `src/index.ts` for server boot
- **`package.json`** — Updated `main`, `types`, `exports` to point to `lib.ts`; added `./config` subpath export
- **`tsup.config.ts`** — Added `src/lib.ts` as build entry
- **`src/lib.test.ts`** — Integration tests: interface shape, lifecycle, health, multiple instances on different ports

## Usage

```typescript
import { createPrismPipe } from 'prism-pipe';

const proxy = createPrismPipe({
  port: 3100,
  providers: { openai: { baseUrl: 'https://api.openai.com', apiKey: '...' } },
  routes: [{ path: '/v1/chat/completions', providers: ['openai'] }],
});

await proxy.start();
await proxy.stop();
```

All 407 tests pass (42 test files).