### PR TITLE
feat: Phase 5 migration + consolidation (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🔷 Prism Pipe
 
-AI proxy with configurable rate limiting, provider fallbacks, structured logging, and format transformation.
+AI proxy with configurable rate limiting, provider fallbacks, structured logging, compose chains, and format transformation.
 
 Split your AI requests like light through a prism.
 
@@ -11,7 +11,7 @@ Split your AI requests like light through a prism.
 OPENAI_API_KEY=sk-... npx prism-pipe
 ```
 
-That's it. Point any OpenAI SDK at `http://localhost:3000` and it works.
+Point any OpenAI SDK at `http://localhost:3000` and it works.
 
 ### With multiple providers (automatic fallback)
 
@@ -24,64 +24,169 @@ If OpenAI is down, requests automatically fall back to Anthropic.
 ## Features
 
 - **Zero config** — `OPENAI_API_KEY=sk-... npx prism-pipe` just works
+- **Programmatic API** — `new PrismPipe()` for full control from TypeScript
+- **Multi-port proxies** — Run multiple proxy configs in a single process
+- **Compose chains** — Chain multiple providers/models per route (planner → executor → reviewer)
 - **Multi-provider fallback** — Chain providers with automatic failover and circuit breaking
 - **Format transformation** — Send OpenAI format, proxy to Anthropic (or vice versa)
+- **Function routes** — Use `RouteHandler` functions for custom request processing
 - **Rate limiting** — Token bucket per IP, configurable via `RATE_LIMIT_RPM`
 - **Request logging** — Every request logged to SQLite for audit/debugging
+- **Log queries** — Query request/usage logs programmatically
 - **Streaming** — SSE passthrough for streaming completions
 - **Auth** — Optional API key auth via `PRISM_API_KEYS`
 - **Docker** — Multi-stage build, multi-arch (amd64 + arm64)
 
-## Usage
+## Programmatic API
 
-### As a drop-in OpenAI proxy
+### Basic — single proxy
 
-```python
-import openai
-client = openai.OpenAI(base_url="http://localhost:3000/v1", api_key="anything")
-resp = client.chat.completions.create(model="gpt-4o", messages=[{"role": "user", "content": "Hello"}])
+```typescript
+import { PrismPipe } from 'prism-pipe';
+
+const prism = new PrismPipe({ logLevel: 'info', storeType: 'sqlite' });
+
+prism.createProxy({
+  id: 'my-proxy',
+  port: 3000,
+  providers: {
+    openai: {
+      baseUrl: 'https://api.openai.com',
+      apiKey: process.env.OPENAI_API_KEY!,
+      format: 'openai',
+    },
+  },
+  routes: {
+    '/v1/chat/completions': { providers: ['openai'] },
+  },
+});
+
+await prism.start();
 ```
 
-### API Endpoints
+### Multi-port — multiple proxies in one process
 
-| Endpoint | Method | Description |
-|---|---|---|
-| `/v1/chat/completions` | POST | Proxy chat completions (OpenAI or Anthropic format) |
-| `/v1/models` | GET | List configured providers and models |
-| `/health` | GET | Health check |
+```typescript
+const prism = new PrismPipe({ logLevel: 'info' });
 
-### Response Headers
+// Port 3100: direct proxy
+prism.createProxy({
+  id: 'direct',
+  port: 3100,
+  providers: {
+    mercury: { baseUrl: 'https://api.inceptionlabs.ai', apiKey: process.env.INCEPTION_API_KEY!, format: 'openai' },
+  },
+  routes: { '/v1/chat/completions': { providers: ['mercury'] } },
+});
 
-Every response includes:
+// Port 3101: compose chain (planner → executor)
+prism.createProxy({
+  id: 'chain',
+  port: 3101,
+  providers: {
+    fast: { baseUrl: 'https://api.inceptionlabs.ai', apiKey: process.env.INCEPTION_API_KEY!, format: 'openai' },
+    smart: { baseUrl: 'https://api.anthropic.com', apiKey: process.env.ANTHROPIC_API_KEY!, format: 'anthropic' },
+  },
+  routes: {
+    '/v1/chat/completions': {
+      compose: {
+        type: 'chain',
+        steps: [
+          { name: 'planner', provider: 'smart', model: 'claude-opus-4-6', systemPrompt: 'Plan the solution.', timeout: 60000 },
+          { name: 'executor', provider: 'fast', model: 'mercury-2', systemPrompt: 'Execute: {{steps.planner.content}}', timeout: 60000 },
+        ],
+      },
+    },
+  },
+});
 
-| Header | Description |
-|---|---|
-| `X-Request-ID` | Unique request identifier |
-| `X-Prism-Provider` | Provider that handled the request |
-| `X-Prism-Latency` | Total latency in milliseconds |
-| `X-Prism-Fallback-Used` | `true` if a fallback provider was used |
-| `X-RateLimit-Limit` | Rate limit capacity |
-| `X-RateLimit-Remaining` | Remaining requests |
-| `X-RateLimit-Reset` | Reset timestamp (Unix seconds) |
+await prism.start();
+```
 
-## Configuration
+### Function routes — custom request handling
 
-### Environment Variables
+```typescript
+import { PrismPipe, type RouteHandler } from 'prism-pipe';
 
-| Variable | Default | Description |
-|---|---|---|
-| `OPENAI_API_KEY` | — | OpenAI API key (auto-configures provider) |
-| `ANTHROPIC_API_KEY` | — | Anthropic API key (auto-configures as fallback) |
-| `PORT` | `3000` | Server port |
-| `LOG_LEVEL` | `info` | Log level (trace/debug/info/warn/error) |
-| `RATE_LIMIT_RPM` | `60` | Requests per minute per IP |
-| `PRISM_API_KEYS` | — | Comma-separated API keys for auth (empty = open) |
-| `STORE_TYPE` | `sqlite` | Storage backend (`sqlite` or `memory`) |
-| `STORE_PATH` | `./data/prism-pipe.db` | SQLite database path |
+const customHandler: RouteHandler = async (req, res) => {
+  // Custom logic before proxying
+  res.json({ message: 'Custom response' });
+};
 
-### Config File
+const prism = new PrismPipe();
+prism.createProxy({
+  id: 'custom',
+  port: 3000,
+  providers: {},
+  routes: { '/v1/custom': customHandler },
+});
+```
 
-For advanced configuration, create `prism-pipe.yaml`:
+### Error handling
+
+```typescript
+prism.onError((event) => {
+  const { error, errorClass, context } = event;
+  console.error(`[${errorClass}] ${context.port}${context.route}: ${error.message}`);
+});
+```
+
+### Log queries
+
+```typescript
+// Query request logs
+const logs = await prism.getLogs({ limit: 100 });
+
+// Usage by model
+const usage = await prism.getUsageByModel();
+
+// Cost by proxy
+const costs = await prism.getCostByProxy();
+```
+
+### Lifecycle
+
+```typescript
+await prism.start();      // Start all proxies
+await prism.stop();       // Stop proxies (keep store open)
+await prism.reload();     // Reload all proxies
+await prism.shutdown();   // Stop everything + close store
+```
+
+### Migration from `createPrismPipe()` factory
+
+The old factory function `createPrismPipe()` has been replaced by the `PrismPipe` class:
+
+```typescript
+// ❌ Old (deprecated)
+import { createPrismPipe } from 'prism-pipe';
+const proxy = createPrismPipe({ port: 3000, providers: { ... } });
+
+// ✅ New
+import { PrismPipe } from 'prism-pipe';
+const prism = new PrismPipe({ logLevel: 'info', storeType: 'sqlite' });
+const proxy = prism.createProxy({ id: 'main', port: 3000, providers: { ... }, routes: { ... } });
+await prism.start();
+```
+
+Key differences:
+- `PrismPipe` is a class, not a factory function
+- Shared store and transform registry across all proxies
+- `createProxy()` returns a `ProxyInstance` — call `prism.start()` to start all
+- Global error handling via `prism.onError()`
+- Usage/cost queries via `prism.getUsageByModel()`, `prism.getCostByProxy()`, etc.
+
+## YAML Configuration
+
+For simple setups, YAML config still works:
+
+```bash
+# Use default prism-pipe.yaml
+npx prism-pipe
+
+# Or specify a config file
+PRISM_CONFIG=configs/my-config.yaml npx prism-pipe
+```
 
 ```yaml
 port: 3000
@@ -103,16 +208,57 @@ routes:
 
 See [`prism-pipe.example.yaml`](./prism-pipe.example.yaml) for the full reference.
 
+## Running All Proxies
+
+```bash
+# Programmatic mode (single process, recommended)
+./start-all.sh
+
+# Legacy YAML mode (3 separate processes)
+./start-all.sh --yaml
+```
+
+See [`examples/programmatic.ts`](./examples/programmatic.ts) for the full multi-port example.
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/v1/chat/completions` | POST | Proxy chat completions (OpenAI or Anthropic format) |
+| `/v1/models` | GET | List configured providers and models |
+| `/health` | GET | Health check |
+
+### Response Headers
+
+| Header | Description |
+|---|---|
+| `X-Request-ID` | Unique request identifier |
+| `X-Prism-Provider` | Provider that handled the request |
+| `X-Prism-Latency` | Total latency in milliseconds |
+| `X-Prism-Fallback-Used` | `true` if a fallback provider was used |
+| `X-RateLimit-Limit` | Rate limit capacity |
+| `X-RateLimit-Remaining` | Remaining requests |
+| `X-RateLimit-Reset` | Reset timestamp (Unix seconds) |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `OPENAI_API_KEY` | — | OpenAI API key (auto-configures provider) |
+| `ANTHROPIC_API_KEY` | — | Anthropic API key (auto-configures as fallback) |
+| `INCEPTION_API_KEY` | — | Inception Labs API key |
+| `PORT` | `3000` | Server port |
+| `LOG_LEVEL` | `info` | Log level (trace/debug/info/warn/error) |
+| `RATE_LIMIT_RPM` | `60` | Requests per minute per IP |
+| `PRISM_API_KEYS` | — | Comma-separated API keys for auth (empty = open) |
+| `STORE_TYPE` | `sqlite` | Storage backend (`sqlite` or `memory`) |
+| `STORE_PATH` | `./data/prism-pipe.db` | SQLite database path |
+
 ## Docker
 
 ```bash
-# Build
 docker build -t prism-pipe .
-
-# Run
 docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... prism-pipe
-
-# Docker Compose
 docker compose up
 ```
 
@@ -129,8 +275,6 @@ npm run check        # Biome lint + format check
 ## Architecture
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
-
-For the proposed future-facing programmatic surface, see [docs/PUBLIC-API.md](./docs/PUBLIC-API.md).
 
 ## License
 

--- a/examples/programmatic.ts
+++ b/examples/programmatic.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env tsx
+/**
+ * Programmatic example: run all 3 proxy configs as a single process.
+ *
+ * This replaces running 3 separate YAML config processes via start-all.sh.
+ * Usage: INCEPTION_API_KEY=... ANTHROPIC_API_KEY=... tsx examples/programmatic.ts
+ */
+
+import { PrismPipe } from '../src/lib';
+
+const prism = new PrismPipe({ logLevel: 'info', storeType: 'sqlite' });
+
+// ── Port 3100: Mercury Direct ──────────────────────────────────────────────
+prism.createProxy({
+  id: 'mercury-direct',
+  port: 3100,
+  providers: {
+    mercury: {
+      name: 'mercury',
+      baseUrl: 'https://api.inceptionlabs.ai',
+      apiKey: process.env.INCEPTION_API_KEY!,
+      format: 'openai',
+    },
+  },
+  routes: {
+    '/v1/chat/completions': { providers: ['mercury'] },
+  },
+});
+
+// ── Port 3101: Opus → Mercury → Opus (planner/executor/reviewer) ──────────
+prism.createProxy({
+  id: 'opus-mercury-opus',
+  port: 3101,
+  providers: {
+    mercury: {
+      name: 'mercury',
+      baseUrl: 'https://api.inceptionlabs.ai',
+      apiKey: process.env.INCEPTION_API_KEY!,
+      format: 'openai',
+    },
+    opus: {
+      name: 'opus',
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: process.env.ANTHROPIC_API_KEY!,
+      format: 'anthropic',
+    },
+  },
+  routes: {
+    '/v1/chat/completions': {
+      compose: {
+        type: 'chain',
+        steps: [
+          {
+            name: 'planner',
+            provider: 'opus',
+            model: 'claude-opus-4-6',
+            systemPrompt: [
+              'You are a senior software architect. Your job is to PLAN, not code.',
+              '',
+              "Given the user's task, produce a clear, ordered plan with:",
+              '1. What files need to be read first (for context)',
+              '2. What changes need to be made (specific files, functions, line-level detail)',
+              '3. What the success criteria are (how to verify it works)',
+              '4. Anti-patterns to avoid',
+              '',
+              'Be specific about file paths relative to the workspace root.',
+              'Do NOT write code — just plan. The executor will implement.',
+            ].join('\n'),
+            inputTransform: '{{original.lastUserMessage}}',
+            timeout: 60000,
+          },
+          {
+            name: 'executor',
+            provider: 'mercury',
+            model: 'mercury-2',
+            systemPrompt: [
+              'You are a fast, precise code executor. You receive a plan from an architect.',
+              '',
+              'PLAN:',
+              '{{steps.planner.content}}',
+              '',
+              'Execute EXACTLY what the plan says. Write complete, working code.',
+              'For each file change, output the COMPLETE file content with clear markers:',
+              '',
+              '=== FILE: path/to/file.ts ===',
+              '(complete file content here)',
+              '=== END FILE ===',
+              '',
+              'Do not deviate from the plan. Do not add features not in the plan.',
+            ].join('\n'),
+            inputTransform:
+              'Execute this plan:\n\n{{steps.planner.content}}\n\nOriginal task: {{original.lastUserMessage}}',
+            timeout: 60000,
+          },
+          {
+            name: 'reviewer',
+            provider: 'opus',
+            model: 'claude-opus-4-6',
+            systemPrompt: [
+              'You are a senior code reviewer. You have:',
+              '1. The original task',
+              "2. The architect's plan",
+              "3. The executor's implementation",
+              '',
+              'Review for: correctness, completeness, edge cases, security, style.',
+              'If GOOD: summarize what was done.',
+              'If ISSUES: list them clearly and include "NEEDS_REVISION".',
+            ].join('\n'),
+            inputTransform: [
+              '## Original Task',
+              '{{original.lastUserMessage}}',
+              '',
+              '## Architect Plan',
+              '{{steps.planner.content}}',
+              '',
+              '## Executor Implementation',
+              '{{steps.executor.content}}',
+              '',
+              'Review the implementation against the plan and original task.',
+            ].join('\n'),
+            timeout: 60000,
+          },
+        ],
+      },
+    },
+  },
+});
+
+// ── Port 3102: Fast Think (thinker → executor) ────────────────────────────
+prism.createProxy({
+  id: 'fast-think',
+  port: 3102,
+  providers: {
+    mercury: {
+      name: 'mercury',
+      baseUrl: 'https://api.inceptionlabs.ai',
+      apiKey: process.env.INCEPTION_API_KEY!,
+      format: 'openai',
+    },
+  },
+  routes: {
+    '/v1/chat/completions': {
+      compose: {
+        type: 'chain',
+        steps: [
+          {
+            name: 'thinker',
+            provider: 'mercury',
+            model: 'mercury-2',
+            systemPrompt: [
+              'Think step by step about how to solve this task.',
+              'List the key considerations, potential issues, and your approach.',
+              'Do NOT write the final answer yet — just think through it.',
+            ].join('\n'),
+            inputTransform:
+              'Think through this problem step by step:\n\n{{original.lastUserMessage}}',
+            timeout: 30000,
+          },
+          {
+            name: 'executor',
+            provider: 'mercury',
+            model: 'mercury-2',
+            systemPrompt: [
+              'You previously thought through this problem. Now execute.',
+              '',
+              'Your thinking:',
+              '{{steps.thinker.content}}',
+              '',
+              'Now produce the final, complete answer.',
+            ].join('\n'),
+            inputTransform:
+              'Based on your analysis:\n{{steps.thinker.content}}\n\nNow produce the final answer for: {{original.lastUserMessage}}',
+            timeout: 30000,
+          },
+        ],
+      },
+    },
+  },
+});
+
+// ── Global error handler ──────────────────────────────────────────────────
+prism.onError((event) => {
+  const { error, context } = event;
+  console.error(`[${context.port ?? '?'}${context.route ?? ''}] ${error.message}`);
+});
+
+// ── Start ─────────────────────────────────────────────────────────────────
+console.log('Starting Prism Pipe (programmatic mode)...');
+await prism.start();
+console.log('✅ All proxies running:');
+for (const proxy of prism.getProxies()) {
+  const s = proxy.status();
+  console.log(`  ${s.id} → :${s.port} [${s.state}]`);
+}
+
+// Graceful shutdown
+for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(signal, async () => {
+    console.log(`\n${signal} received, shutting down...`);
+    await prism.shutdown();
+    process.exit(0);
+  });
+}

--- a/prism-pipe.example.yaml
+++ b/prism-pipe.example.yaml
@@ -37,20 +37,7 @@ requestTimeout: 120000
 #     providers: [anthropic]
 #     systemPrompt: "Think step by step."
 
-<<<<<<< HEAD
-  # Example: Anthropic-first route with system prompt
-  # - path: /v1/smart
-  #   providers:
-  #     - anthropic
-  #     - openai
-  #   systemPrompt: "You are a helpful AI assistant."
-  #   pipeline:
-  #     - log-request
-  #     - inject-system
-  #     - transform-format
-=======
 # Rate limiting — set RATE_LIMIT_RPM env var (default: 60 req/min)
 # Auth — set PRISM_API_KEYS env var (comma-separated) to enable
 # Store — defaults to SQLite at ./data/prism-pipe.db
 #   Set STORE_TYPE=memory for in-memory (testing/edge)
->>>>>>> 549e39d (feat: MVP integration — end-to-end proxy with zero-config npx start (#10))

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -49,3 +49,4 @@ export type { PrismConfig } from './prism-pipe';
 export { PrismPipe } from './prism-pipe';
 export type { ProxyHealthInfo } from './proxy-instance';
 export { ProxyInstance } from './proxy-instance';
+export type { LogQuery, RequestLogEntry, UsageLogEntry, UsageLogQuery } from './store/interface';

--- a/start-all.sh
+++ b/start-all.sh
@@ -1,15 +1,35 @@
 #!/bin/bash
 # Start all Prism Pipe instances
-export INCEPTION_API_KEY=sk_0b907b1752a9f633a99abb960c38730a
-export ANTHROPIC_API_KEY=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
+#
+# Modes:
+#   ./start-all.sh              — Programmatic mode (single process, recommended)
+#   ./start-all.sh --yaml       — Legacy YAML mode (3 separate processes)
+#
+# Required env vars:
+#   INCEPTION_API_KEY
+#   ANTHROPIC_API_KEY
 
-cd /home/kadajett/prism-pipe
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ -z "${INCEPTION_API_KEY:-}" ] || [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "❌ Required env vars: INCEPTION_API_KEY, ANTHROPIC_API_KEY"
+  echo "   Export them or create a .env file."
+  exit 1
+fi
+
+# ── Programmatic mode (default) ─────────────────────────────────────────────
+if [ "${1:-}" != "--yaml" ]; then
+  echo "Starting Prism Pipe (programmatic — single process)..."
+  exec npx tsx examples/programmatic.ts
+fi
+
+# ── Legacy YAML mode ────────────────────────────────────────────────────────
+echo "Starting Prism Pipe (YAML — 3 separate processes)..."
 
 # Kill any existing instances
-pkill -f "node dist/index.js" 2>/dev/null
+pkill -f "node dist/index.js" 2>/dev/null || true
 sleep 1
-
-echo "Starting Prism Pipe instances..."
 
 # Mercury Direct — port 3100
 PRISM_CONFIG=configs/mercury-direct.yaml nohup node dist/index.js > /tmp/prism-pipe-3100.log 2>&1 &
@@ -27,6 +47,6 @@ sleep 2
 
 # Health checks
 for port in 3100 3101 3102; do
-  status=$(curl -s http://localhost:$port/health | jq -r .status 2>/dev/null || echo "down")
+  status=$(curl -s "http://localhost:$port/health" | jq -r .status 2>/dev/null || echo "down")
   echo "  Port $port: $status"
 done


### PR DESCRIPTION
Addresses issue #74

## Changes

- **`examples/programmatic.ts`** — Full example showing all 3 YAML configs as one programmatic process using PrismPipe class
- **`start-all.sh`** — Rewritten with programmatic mode (default) and `--yaml` fallback; no hardcoded API keys
- **`README.md`** — New API docs: PrismPipe class, migration guide from createPrismPipe(), multi-port, compose chains, function routes, error handling, log queries
- **`src/lib.ts`** — Export LogQuery, RequestLogEntry, UsageLogEntry, UsageLogQuery from package entry
- **`prism-pipe.example.yaml`** — Resolved merge conflict markers

## Verification
- `npx tsc --noEmit` passes
- All 452 tests pass
- `npm run build` succeeds with all types in dist/lib.d.ts