### PR TITLE
fix: remove duplicate ensureGlobal and document global sanitize

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,35 @@ npm run test:run     # Tests
 npm run check        # Biome lint + format check
 ```
 
+## Prompt Guard Middleware
+
+PrismPipe includes a built-in prompt injection detection middleware (`prompt-guard`) that scans user messages for known injection patterns and takes a configurable action.
+
+### Actions
+
+| Action | Behaviour |
+|---|---|
+| `block` (default) | Throws a `PipelineError` (HTTP 400) when the threat score exceeds the threshold. |
+| `flag` | Sets `promptGuard.flagged` metadata and continues. |
+| `sanitize` | Strips **all** occurrences of matched patterns from message text, then continues. Uses global regex matching so repeated injection attempts within the same message are fully removed. |
+| `log` | Logs the detection at `warn` level and continues. |
+
+### Configuration
+
+```ts
+createPromptGuard({
+  action: 'sanitize',   // 'block' | 'flag' | 'sanitize' | 'log'
+  threshold: 0.5,       // score 0–1 to trigger action
+  excludeRoles: ['system', 'assistant'],
+  maxScanLength: 10_000,
+  patterns: [],          // additional PatternRule[] merged with built-ins
+});
+```
+
+### Global Sanitization
+
+When `action` is `'sanitize'`, the middleware removes **every** match of each pattern — not just the first. This is achieved via the internal `ensureGlobal()` helper that adds the `g` flag to any regex missing it, ensuring `String.replace` behaves like `replaceAll`. This applies to both plain `string` and `ContentBlock[]` message content.
+
 ## Architecture
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.

--- a/docs/prompt-guard.md
+++ b/docs/prompt-guard.md
@@ -31,7 +31,7 @@ routes:
 
 - **`block`** — Throws `PipelineError` with code `content_filter` (HTTP 400). Request is rejected.
 - **`flag`** — Sets `ctx.metadata` fields (`promptGuard.flagged`, `promptGuard.score`, `promptGuard.matches`) and continues. Downstream middleware/handlers can inspect these.
-- **`sanitize`** — Strips matched patterns from message text and continues. Sets `promptGuard.sanitized` metadata.
+- **`sanitize`** — Strips **all** occurrences of matched patterns from message text (global regex replacement) and continues. Sets `promptGuard.sanitized` metadata.
 - **`log`** — Logs a warning with score/matches and continues unchanged.
 
 ## Pattern Categories

--- a/src/middleware/prompt-guard.ts
+++ b/src/middleware/prompt-guard.ts
@@ -273,15 +273,6 @@ export function ensureGlobal(re: RegExp): RegExp {
  * Uses global regexes so every match is removed, not just the first.
  * @internal
  */
-/**
- * Ensure a RegExp has the global flag so `.replace()` strips *all* occurrences.
- * Returns the original regex when it already has `g`; otherwise creates a copy.
- * @internal
- */
-function ensureGlobal(re: RegExp): RegExp {
-  return re.global ? re : new RegExp(re.source, re.flags + 'g');
-}
-
 function sanitizeContent(
   content: string | ContentBlock[],
   patterns: PatternRule[],


### PR DESCRIPTION
Addresses issue #123

## Changes

- Removed duplicate private `ensureGlobal` function (leftover from PR #120 merge). The exported version at line 267 was already correct and used by `sanitizeContent`.
- Updated `docs/prompt-guard.md` to note that sanitize action uses global regex replacement (strips **all** occurrences, not just the first).

## Verification

All 32 existing tests pass, including the global-match sanitize tests added in PR #120.